### PR TITLE
feat(skill): expand agent-skills with MCP-grounded skills + plugin packaging (epic #8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "kestra-io",
+  "owner": {
+    "name": "Kestra",
+    "url": "https://github.com/kestra-io"
+  },
+  "plugins": [
+    {
+      "name": "kestra-agent-skills",
+      "source": "./",
+      "description": "Kestra agent skills — flow authoring, production hardening, kestractl operations, GitOps CI/CD, and Airflow migration.",
+      "homepage": "https://kestra.io/docs/ai-tools/agent-skills",
+      "repository": "https://github.com/kestra-io/agent-skills",
+      "keywords": ["kestra", "orchestration", "workflows", "kestractl", "mcp"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
   },
   "homepage": "https://kestra.io/docs/ai-tools/agent-skills",
   "repository": "https://github.com/kestra-io/agent-skills",
-  "keywords": ["kestra", "orchestration", "workflows", "kestractl", "mcp", "data-pipelines"]
+  "keywords": ["kestra", "orchestration", "workflows", "kestractl", "mcp", "data-pipelines"],
+  "hooks": "./hooks/hooks.json"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "kestra-agent-skills",
+  "description": "Author, harden, operate, and set up CI/CD for Kestra, and migrate to it — grounded in the Kestra MCP server and kestractl.",
+  "author": {
+    "name": "Kestra",
+    "url": "https://kestra.io"
+  },
+  "homepage": "https://kestra.io/docs/ai-tools/agent-skills",
+  "repository": "https://github.com/kestra-io/agent-skills",
+  "keywords": ["kestra", "orchestration", "workflows", "kestractl", "mcp", "data-pipelines"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# kestractl binary when installed self-contained via scripts/ensure-kestractl.sh --install-dir <skill>/scripts/bin
+skills/kestra-ops/scripts/bin/

--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ Use migrate-airflow-kestra to migrate dags/ingest_pipeline.py from Airflow to Ke
     │   └── references/
     │       └── hardening-patterns.md
     ├── kestra-ops/
-    │   └── SKILL.md
+    │   ├── SKILL.md
+    │   └── references/
+    │       ├── commands.md
+    │       └── workflow.md
     └── migrate-airflow-kestra/
         └── SKILL.md
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A curated collection of agent skills for operating Kestra environments.
 
 ### kestra-flow
 
-Generate, modify, or debug Kestra Flow YAML grounded in the live flow schema — the same way the Kestra AI Copilot does.
+Generate, modify, or debug Kestra Flow YAML grounded in the live schema via the Kestra MCP server — the same way the Kestra AI Copilot does.
 
 **Use when:**
 - Generating a new Kestra flow from a description
@@ -15,7 +15,7 @@ Generate, modify, or debug Kestra Flow YAML grounded in the live flow schema —
 - Debugging invalid YAML or incorrect task/trigger references
 
 **Covers:**
-- Fetching the live flow schema from `https://api.kestra.io/v1/plugins/schemas/flow`
+- Incremental, on-demand schema grounding via `mcp__kestra__*` — flow structure from `list_doc_children` / `get_doc`, types from `search` / `plugin_tasks`, per-task schema from `task_schema` (no multi-MB download)
 - Schema-validated task and trigger generation
 - Partial modification (touch only the relevant part)
 - Guardrails: no invented types, no hardcoded secrets, correct looping and trigger patterns

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ Skill path: `skills/kestra-flow-hardening/SKILL.md`
 
 ### kestra-ops
 
-Operate Kestra using `kestractl` for flow, execution, namespace, and namespace-file operations.
+Operate Kestra using `kestractl` across flows, executions, triggers, KV, namespaces, and namespace files.
 
 **Use when:**
 - Validating or deploying flows
 - Triggering executions and checking status
-- Managing namespaces and `nsfiles`
+- Managing triggers, KV entries, namespaces, and `nsfiles`
 - Configuring or switching CLI contexts
 
 **Covers:**
-- Context and auth setup (`config add`, `config use`, `config show`)
-- Read and inspection flows (`flows list/get`, `executions get`, `namespaces list`)
-- Safe write operations (`flows deploy`, `nsfiles upload/delete`)
+- Short `SKILL.md` entry point + on-demand `references/` (progressive disclosure)
+- `references/commands.md` — the full `kestractl` command surface, pinned to a release, with EE-only groups marked
+- `references/workflow.md` — edition (OSS/EE) awareness, per-group decision notes, `--wait` vs. poll, `*-by-query` vs. loop, revision-awareness, and guardrails
 - Operational guardrails for production and automation output
 
 Skill path: `skills/kestra-ops/SKILL.md`

--- a/README.md
+++ b/README.md
@@ -28,19 +28,22 @@ Skill path: `skills/kestra-flow/SKILL.md`
 
 ### kestra-flow-hardening
 
-Audit existing Kestra flows and add production-hardening controls — the consulting counterpart to `kestra-flow`.
+Audit existing Kestra flows, add production-hardening controls, and diagnose failures — the consulting counterpart to `kestra-flow`.
 
 **Use when:**
 - Hardening one or more flows for production
 - Auditing flows for resilience, idempotency, and guardrail gaps
 - Adding retries, timeouts, error handling, concurrency limits, SLAs, or idempotency guards
+- Diagnosing why a flow or execution failed ("troubleshoot mode")
 
 **Covers:**
 - Severity-ranked audit report (Critical / High / Medium / Low) with risk, caveat, and proposed fix per finding
+- Troubleshoot mode — root-cause a failure grounded in version-pinned docs (`search_docs` / `get_doc`) and `task_schema`, citing the page used; `references/troubleshooting.md` maps common failure signatures
 - Idempotency judgment — never recommends a blind retry on a non-idempotent write; flags the dedup-guard vs. retry-if-safe branches
 - Proportional auditing calibrated by flow signals (triggers, side-effects, namespace env); "already sound" is a valid result
 - Surgical, schema-validated edits applied on confirmation, inline and structure-preserving
 - Version- and edition-aware (OSS / EE), with EE-only patterns labeled and given an OSS fallback
+- MCP-grounded — no schema download; flow structure from `list_doc_children` / `get_doc`, types from `task_schema`
 
 Skill path: `skills/kestra-flow-hardening/SKILL.md`
 
@@ -118,7 +121,8 @@ Use migrate-airflow-kestra to migrate dags/ingest_pipeline.py from Airflow to Ke
     ├── kestra-flow-hardening/
     │   ├── SKILL.md
     │   └── references/
-    │       └── hardening-patterns.md
+    │       ├── hardening-patterns.md
+    │       └── troubleshooting.md
     ├── kestra-ops/
     │   ├── SKILL.md
     │   ├── references/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Generate, modify, or debug Kestra Flow YAML grounded in the live schema via the 
 **Covers:**
 - Blueprint-first scaffolding — search vetted templates via `blueprints` / `get_blueprint_flow`, adapt rather than generate from scratch, EE-only blueprints gated for OSS users
 - Incremental, on-demand schema grounding via `mcp__kestra__*` — flow structure from `list_doc_children` / `get_doc`, types from `search` / `plugin_tasks`, per-task schema from `task_schema` (no multi-MB download)
+- Resolve, don't guess — task runners, storage, secret managers, and log shippers via `list_*`; plugin/version compatibility via `versions` / `plugin_versions`
 - Schema-validated task and trigger generation
 - Partial modification (touch only the relevant part)
 - Guardrails: no invented types, no hardcoded secrets, correct looping and trigger patterns

--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ Skill path: `skills/kestra-ops/SKILL.md`
 
 ---
 
+### kestra-cicd
+
+Scaffold a GitOps CI/CD pipeline that validates flows on PR/MR and deploys on merge, wrapping `kestractl` — the "automate the operating" companion to `kestra-ops`.
+
+**Use when:**
+- Setting up CI/CD or GitOps for Kestra flows
+- Generating a GitHub Actions or GitLab CI pipeline that validates on PR and deploys on merge
+- Wiring per-environment namespaces with a manual gate before production
+
+**Covers:**
+- `references/github-actions.md` — raw-`kestractl` workflow + an official-`kestra-io/github-actions` variant
+- `references/gitlab-ci.md` — `.gitlab-ci.yml` with MR validation and manual staging/prod gates
+- Secrets via the CI secret store only, pinned `kestractl` version, `system.readOnly` on CI-managed flows
+- Defers operational `kestractl` (install/config/commands) to `kestra-ops`
+
+Skill path: `skills/kestra-cicd/SKILL.md`
+
+---
+
 ### migrate-airflow-kestra
 
 Migrate an **Apache Airflow** DAG to a production-ready **Kestra** flow.
@@ -110,6 +129,10 @@ Use kestra-ops to run my-flow in my.namespace, wait for completion, and summariz
 Use migrate-airflow-kestra to migrate dags/ingest_pipeline.py from Airflow to Kestra, output to kestra/.
 ```
 
+```text
+Use kestra-cicd to scaffold a GitHub Actions pipeline that validates flows/ on PRs and deploys to prod.namespace on merge to main.
+```
+
 ## Structure
 
 ```
@@ -130,6 +153,11 @@ Use migrate-airflow-kestra to migrate dags/ingest_pipeline.py from Airflow to Ke
     │   │   └── workflow.md
     │   └── scripts/
     │       └── ensure-kestractl.sh
+    ├── kestra-cicd/
+    │   ├── SKILL.md
+    │   └── references/
+    │       ├── github-actions.md
+    │       └── gitlab-ci.md
     └── migrate-airflow-kestra/
         └── SKILL.md
 ```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Operate Kestra using `kestractl` across flows, executions, triggers, KV, namespa
 - Short `SKILL.md` entry point + on-demand `references/` (progressive disclosure)
 - `references/commands.md` — the full `kestractl` command surface, pinned to a release, with EE-only groups marked
 - `references/workflow.md` — edition (OSS/EE) awareness, per-group decision notes, `--wait` vs. poll, `*-by-query` vs. loop, revision-awareness, and guardrails
+- `scripts/ensure-kestractl.sh` — dry-run check for `kestractl`, with on-request install/upgrade via the official installer
 - Operational guardrails for production and automation output
 
 Skill path: `skills/kestra-ops/SKILL.md`
@@ -118,9 +119,11 @@ Use migrate-airflow-kestra to migrate dags/ingest_pipeline.py from Airflow to Ke
     │       └── hardening-patterns.md
     ├── kestra-ops/
     │   ├── SKILL.md
-    │   └── references/
-    │       ├── commands.md
-    │       └── workflow.md
+    │   ├── references/
+    │   │   ├── commands.md
+    │   │   └── workflow.md
+    │   └── scripts/
+    │       └── ensure-kestractl.sh
     └── migrate-airflow-kestra/
         └── SKILL.md
 ```

--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ Use migrate-airflow-kestra to migrate dags/ingest_pipeline.py from Airflow to Ke
 Use kestra-cicd to scaffold a GitHub Actions pipeline that validates flows/ on PRs and deploys to prod.namespace on merge to main.
 ```
 
+## Telemetry
+
+When a skill here shells out to `kestractl`, `kestractl` fires its usual anonymous
+`cli_command_executed` PostHog event (command path, success, duration, versions,
+os/arch — no flow content, no secrets).
+
+To tell skill-driven CLI use apart from a human running `kestractl` directly, the
+`kestra-ops` and `migrate-airflow-kestra` skills `export KESTRACTL_SKILL_SOURCE=<skill-name>`
+before invoking it. Once a companion `kestractl` release reads that variable, it is
+attached as a `skill_source` property on the event (analogous to `ci_provider`).
+Until then the variable is simply ignored — nothing changes.
+
+**Opt out** of all `kestractl` telemetry:
+
+```bash
+export KESTRACTL_TELEMETRY_DISABLED=true
+```
+
 ## Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -107,6 +107,31 @@ Migrate an **Apache Airflow** DAG to a production-ready **Kestra** flow.
 
 Skill path: `skills/migrate-airflow-kestra/SKILL.md`
 
+## Install
+
+### As a Claude Code plugin (recommended)
+
+This repo is a self-registering [Claude Code](https://code.claude.com/docs/en/plugins)
+marketplace bundling every skill into one plugin, `kestra-agent-skills`:
+
+```text
+/plugin marketplace add kestra-io/agent-skills
+/plugin install kestra-agent-skills@kestra-io
+```
+
+Skills are then namespaced — `kestra-agent-skills:kestra-flow`,
+`kestra-agent-skills:kestra-ops`, and so on. Updates roll forward with the repo
+(no pinned `version`); re-run `/plugin marketplace update kestra-io` to pull the
+latest. CLI equivalents: `claude plugin marketplace add …` / `claude plugin install …`.
+
+### Manual copy
+
+Copy an individual skill into your skills directory:
+
+```bash
+cp -r skills/kestra-flow ~/.claude/skills/kestra-flow
+```
+
 ## Usage
 
 Load the skill and provide a concrete operational objective.
@@ -138,6 +163,9 @@ Use kestra-cicd to scaffold a GitHub Actions pipeline that validates flows/ on P
 ```
 .
 ├── README.md
+├── .claude-plugin/
+│   ├── plugin.json          # bundles skills/ as the kestra-agent-skills plugin
+│   └── marketplace.json     # self-registers the repo as the "kestra-io" marketplace
 └── skills/
     ├── kestra-flow/
     │   └── SKILL.md

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Generate, modify, or debug Kestra Flow YAML grounded in the live schema via the 
 - Debugging invalid YAML or incorrect task/trigger references
 
 **Covers:**
+- Blueprint-first scaffolding — search vetted templates via `blueprints` / `get_blueprint_flow`, adapt rather than generate from scratch, EE-only blueprints gated for OSS users
 - Incremental, on-demand schema grounding via `mcp__kestra__*` — flow structure from `list_doc_children` / `get_doc`, types from `search` / `plugin_tasks`, per-task schema from `task_schema` (no multi-MB download)
 - Schema-validated task and trigger generation
 - Partial modification (touch only the relevant part)

--- a/README.md
+++ b/README.md
@@ -160,20 +160,26 @@ Use kestra-cicd to scaffold a GitHub Actions pipeline that validates flows/ on P
 
 ## Telemetry
 
-When a skill here shells out to `kestractl`, `kestractl` fires its usual anonymous
-`cli_command_executed` PostHog event (command path, success, duration, versions,
-os/arch — no flow content, no secrets).
+Anonymous usage metadata only — never prompt content, flow content, or secrets.
 
-To tell skill-driven CLI use apart from a human running `kestractl` directly, the
-`kestra-ops` and `migrate-airflow-kestra` skills `export KESTRACTL_SKILL_SOURCE=<skill-name>`
-before invoking it. Once a companion `kestractl` release reads that variable, it is
-attached as a `skill_source` property on the event (analogous to `ci_provider`).
-Until then the variable is simply ignored — nothing changes.
+**Skill invocations.** Installed as a plugin, this repo ships a Claude Code
+`PostToolUse` hook (`hooks/skill-usage.sh`) that fires one PostHog event
+(`agent_skill_invoked`) per skill use, with the skill name, plugin git ref, and
+os/arch. It is best-effort: no `curl`, a disabled flag, or a network failure makes
+it a silent no-op that never blocks the session. Manual (non-plugin) installs can
+wire the same hook into `~/.claude/settings.json`.
 
-**Opt out** of all `kestractl` telemetry:
+**`kestractl` commands.** When a skill shells out to `kestractl`, `kestractl` fires
+its usual anonymous `cli_command_executed` event. The `kestra-ops` and
+`migrate-airflow-kestra` skills `export KESTRACTL_SKILL_SOURCE=<skill-name>` first;
+once a companion `kestractl` release reads it, it is attached as a `skill_source`
+property (analogous to `ci_provider`). Until then the variable is ignored.
+
+**Opt out** of everything:
 
 ```bash
-export KESTRACTL_TELEMETRY_DISABLED=true
+export KESTRA_SKILLS_TELEMETRY_DISABLED=true   # the skill-invocation hook
+export KESTRACTL_TELEMETRY_DISABLED=true       # kestractl commands (also disables the hook)
 ```
 
 ## Structure
@@ -184,6 +190,9 @@ export KESTRACTL_TELEMETRY_DISABLED=true
 ├── .claude-plugin/
 │   ├── plugin.json          # bundles skills/ as the kestra-agent-skills plugin
 │   └── marketplace.json     # self-registers the repo as the "kestra-io" marketplace
+├── hooks/
+│   ├── hooks.json           # PostToolUse:Skill -> skill-usage.sh
+│   └── skill-usage.sh       # anonymous per-skill usage event (best-effort, opt-out)
 └── skills/
     ├── kestra-flow/
     │   └── SKILL.md

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/skill-usage.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/skill-usage.sh
+++ b/hooks/skill-usage.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# skill-usage.sh — Claude Code PostToolUse hook (matcher: Skill).
+#
+# Fires one anonymous PostHog event per skill invocation so skill adoption is
+# measurable. Metadata only — the skill name, plugin ref, and os/arch. It never
+# reads the prompt, the transcript, the cwd, or any flow content.
+#
+# Best-effort by design: any missing dependency, disabled flag, or network
+# failure results in a silent `exit 0`. It must never block or fail a session.
+#
+# Opt out:  export KESTRACTL_TELEMETRY_DISABLED=true
+#      or:  export KESTRA_SKILLS_TELEMETRY_DISABLED=true
+#
+# Override destination (defaults target Kestra's PostHog EU project):
+#   KESTRA_SKILLS_POSTHOG_KEY   KESTRA_SKILLS_POSTHOG_HOST
+set -euo pipefail
+
+is_true() { case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in 1|true|yes|on) return 0;; *) return 1;; esac; }
+
+is_true "${KESTRACTL_TELEMETRY_DISABLED:-}"     && exit 0
+is_true "${KESTRA_SKILLS_TELEMETRY_DISABLED:-}" && exit 0
+
+command -v curl >/dev/null 2>&1 || exit 0
+
+POSTHOG_KEY="${KESTRA_SKILLS_POSTHOG_KEY:-phc_8lNe3YuQj9gyJcCJOGy4RwMCUFzHQ7siGPr8aeodhxR}"
+POSTHOG_HOST="${KESTRA_SKILLS_POSTHOG_HOST:-https://eu.i.posthog.com}"
+[ -n "$POSTHOG_KEY" ] || exit 0
+
+# --- read the hook payload from stdin, pull out the skill name ---------------
+payload="$(cat 2>/dev/null || true)"
+skill=""
+if command -v jq >/dev/null 2>&1; then
+  skill="$(printf '%s' "$payload" | jq -r '.tool_input.skill // .tool_input.name // empty' 2>/dev/null || true)"
+fi
+if [ -z "$skill" ]; then
+  skill="$(printf '%s' "$payload" | sed -n 's/.*"skill"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+fi
+[ -n "$skill" ] || exit 0
+
+# --- stable anonymous id (random, persisted; never derived from user data) ---
+id_dir="${CLAUDE_PLUGIN_DATA:-${HOME:-/tmp}/.claude}"
+id_file="${id_dir}/kestra-skills-telemetry-id"
+distinct_id=""
+if [ -r "$id_file" ]; then
+  distinct_id="$(head -n1 "$id_file" 2>/dev/null || true)"
+fi
+if [ -z "$distinct_id" ]; then
+  if command -v uuidgen >/dev/null 2>&1; then distinct_id="$(uuidgen)"; else
+    distinct_id="anon-$(head -c16 /dev/urandom 2>/dev/null | od -An -tx1 | tr -d ' \n' || echo unknown)"
+  fi
+  ( mkdir -p "$id_dir" 2>/dev/null && printf '%s\n' "$distinct_id" > "$id_file" 2>/dev/null ) || true
+fi
+
+plugin_ref=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && command -v git >/dev/null 2>&1; then
+  plugin_ref="$(git -C "$CLAUDE_PLUGIN_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+fi
+
+esc() { printf '%s' "${1:-}" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+body="$(cat <<JSON
+{"api_key":"$(esc "$POSTHOG_KEY")","event":"agent_skill_invoked","distinct_id":"$(esc "$distinct_id")","properties":{"skill":"$(esc "$skill")","plugin":"kestra-agent-skills","plugin_ref":"$(esc "$plugin_ref")","os":"$(esc "$(uname -s 2>/dev/null)")","arch":"$(esc "$(uname -m 2>/dev/null)")","source":"claude-code-hook","\$lib":"kestra-agent-skills"}}
+JSON
+)"
+
+# fire-and-forget; capped so a slow network can't hang the session
+( curl -sS -m 5 -o /dev/null \
+    -X POST "${POSTHOG_HOST%/}/i/v0/e/" \
+    -H 'Content-Type: application/json' \
+    --data-raw "$body" >/dev/null 2>&1 || true ) &
+
+exit 0

--- a/skills/kestra-cicd/SKILL.md
+++ b/skills/kestra-cicd/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: kestra-cicd
+description: Scaffold a GitOps CI/CD pipeline that validates Kestra flows on pull/merge requests and deploys them on merge, wrapping kestractl. Supports GitHub Actions and GitLab CI, per-environment namespaces, and manual approval gating for production. Use when users ask to set up CI/CD, GitOps, or an automated validate/deploy pipeline for their Kestra flows.
+argument-hint: "[github|gitlab] [flows-dir]"
+compatibility: Generates pipeline definition files only. No Kestra instance or MCP server required.
+---
+
+# Kestra CI/CD Skill
+
+Scaffold a GitOps pipeline that runs `kestractl flows validate` on every
+pull/merge request and `kestractl flows deploy` on merge to a protected branch,
+with per-environment namespaces and a manual gate before production.
+
+This is the "automate the operating" companion to `kestra-ops` (interactive
+`kestractl`). It **generates pipeline files** — it does not run deployments.
+
+## When to use
+
+- "Set up CI/CD for my Kestra flows."
+- "GitHub Actions / GitLab CI to validate on PR and deploy on merge."
+- "GitOps pipeline for Kestra with dev/staging/prod."
+
+## Required inputs
+
+- **CI provider** — GitHub Actions (default) or GitLab CI.
+- **Flows directory** in the repo (e.g. `flows/`). Namespace-files directory if any.
+- **Kestra host(s) and tenant(s).**
+- **Environment model** — single, or dev / staging / prod — and the namespace
+  mapping per environment.
+- **Branch strategy** — which branch deploys where; whether prod needs a manual gate
+  (default: yes).
+- **Auth** — API token (EE) or username/password (OSS), always via the CI secret store.
+
+## Use `kestra-ops` for operational `kestractl`
+
+If the `kestra-ops` skill is available, use it for **any `kestractl` install,
+configuration, or command you run yourself** while building or testing the
+pipeline — its `scripts/ensure-kestractl.sh`, `references/commands.md`, and
+`references/workflow.md` are the source of truth for flags, failure handling, and
+guardrails. Do not install or configure `kestractl` directly from this skill.
+This skill only *generates* the pipeline definition; the generated pipeline
+installs `kestractl` in its own runner.
+
+## GitHub-native alternative
+
+For GitHub, Kestra also ships official actions —
+`kestra-io/github-actions/validate-flows`, `deploy-flows`,
+`deploy-namespace-files` — which wrap the CLI with no install step. Prefer them
+for a standard GitHub setup; use the raw-`kestractl` template when you need
+offline validation, provider parity with a GitLab pipeline, or full flag control.
+The GitHub reference covers both.
+
+## Workflow
+
+1. Gather the inputs above; fill sensible defaults for anything unspecified and
+   state the assumptions.
+2. Load the matching reference and copy its template:
+   - [`references/github-actions.md`](references/github-actions.md)
+   - [`references/gitlab-ci.md`](references/gitlab-ci.md)
+3. Replace every `<PLACEHOLDER>` — flows dir, hosts, tenants, namespaces, branch
+   names, secret names, pinned `kestractl` version.
+4. Write the file to its conventional path (`.github/workflows/kestra-cicd.yml` or
+   `.gitlab-ci.yml`).
+5. Explain: which secrets/variables to create in the provider, what each job does,
+   how the prod gate works, and what to tune.
+
+## Pipeline design principles
+
+- **Validate before deploy.** PR/MR runs `kestractl flows validate <dir>` and fails
+  the check on non-zero. Deploy jobs `needs:`/`depends_on` a green validate.
+- **Deploy on merge, not on PR.** Deploy triggers only on push to the protected
+  branch (or a release tag).
+- **One job per environment.** Map branch/tag → namespace. Prod behind a manual
+  approval: GitHub `environment:` protection, GitLab `when: manual`.
+- **Pin `kestractl`.** Install a fixed version in the runner via the official
+  installer (`curl -fsSL …/install-scripts/install.sh | VERSION=<x> bash`), never
+  `latest`.
+- **Secrets only from the CI store**, surfaced as `KESTRACTL_HOST` /
+  `KESTRACTL_TENANT` / `KESTRACTL_TOKEN` (or `KESTRACTL_USERNAME` /
+  `KESTRACTL_PASSWORD`) env vars. Never inline a token or pass it as a literal
+  `--token` argument.
+- **`--override` deliberately.** Use it when the pipeline is the source of truth
+  for those flows. Consider `kestractl flows namespace-sync` when the pipeline
+  should also delete flows removed from the repo — gate that carefully.
+- **`--fail-fast`** on deploy so a bad flow stops the rollout; report which flows
+  deployed and which failed.
+
+## Guardrails
+
+- Credentials only via the CI provider's secret store; mark them masked/protected.
+- Production deploy always gated (manual approval / protected environment /
+  protected branch) unless the user explicitly opts out.
+- Least-privilege token — scoped to the target namespace(s) where possible.
+- Add `labels: {system.readOnly: "true"}` to CI-managed flows so the UI editor is
+  disabled and the repo stays the source of truth.
+- Pin the `kestractl` version; bump it deliberately.
+- Never echo secrets; no `--verbose` in pipeline logs.
+
+## Example prompts
+
+- "Scaffold a GitHub Actions pipeline that validates `flows/` on PRs and deploys to
+  the `prod` namespace on merge to `main`."
+- "Set up GitLab CI for Kestra with dev auto-deploy and manual staging/prod gates."
+- "Add a CI/CD workflow for my Kestra flows with per-environment namespaces
+  (`dev.*`, `staging.*`, `prod.*`)."

--- a/skills/kestra-cicd/references/github-actions.md
+++ b/skills/kestra-cicd/references/github-actions.md
@@ -1,0 +1,141 @@
+# GitHub Actions — Kestra CI/CD
+
+Two templates: **raw `kestractl`** (provider-agnostic, offline-capable, full flag
+control) and the **official Kestra actions** (no install step). Pick one.
+
+Replace every `<PLACEHOLDER>`. Create the referenced secrets under
+**Settings → Secrets and variables → Actions**, and one **Environment** per
+deploy target (Settings → Environments) with required reviewers on `production`.
+
+---
+
+## Template A — raw `kestractl`
+
+`.github/workflows/kestra-cicd.yml`
+
+```yaml
+name: Kestra CI/CD
+
+on:
+  pull_request:
+    paths:
+      - "<FLOWS_DIR>/**"          # e.g. flows/**
+      - ".github/workflows/kestra-cicd.yml"
+  push:
+    branches:
+      - <MAIN_BRANCH>             # e.g. main
+
+env:
+  KESTRACTL_VERSION: "<KESTRACTL_VERSION>"   # e.g. 1.18.1 — pin it, never "latest"
+  FLOWS_DIR: "<FLOWS_DIR>"                    # e.g. flows
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kestractl
+        run: curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION="${KESTRACTL_VERSION}" INSTALL_DIR="$HOME/.local/bin" bash
+      - name: Add kestractl to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Validate flows
+        env:
+          KESTRACTL_HOST: ${{ secrets.KESTRA_HOST }}
+          KESTRACTL_TENANT: ${{ secrets.KESTRA_TENANT }}
+          KESTRACTL_TOKEN: ${{ secrets.KESTRA_TOKEN }}        # EE
+          # KESTRACTL_USERNAME: ${{ secrets.KESTRA_USERNAME }}  # OSS basic auth
+          # KESTRACTL_PASSWORD: ${{ secrets.KESTRA_PASSWORD }}
+        run: kestractl flows validate "${FLOWS_DIR}" --output json
+
+  deploy-staging:
+    if: github.ref == 'refs/heads/<MAIN_BRANCH>'
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kestractl
+        run: curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION="${KESTRACTL_VERSION}" INSTALL_DIR="$HOME/.local/bin" bash
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Deploy to staging
+        env:
+          KESTRACTL_HOST: ${{ secrets.KESTRA_HOST }}
+          KESTRACTL_TENANT: ${{ secrets.KESTRA_TENANT }}
+          KESTRACTL_TOKEN: ${{ secrets.KESTRA_TOKEN }}
+        run: kestractl flows deploy "${FLOWS_DIR}" --namespace <STAGING_NAMESPACE> --override --fail-fast --output json
+
+  deploy-production:
+    if: github.ref == 'refs/heads/<MAIN_BRANCH>'
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    environment: production          # add required reviewers here = the manual gate
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kestractl
+        run: curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION="${KESTRACTL_VERSION}" INSTALL_DIR="$HOME/.local/bin" bash
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Deploy to production
+        env:
+          KESTRACTL_HOST: ${{ secrets.KESTRA_HOST_PROD }}
+          KESTRACTL_TENANT: ${{ secrets.KESTRA_TENANT_PROD }}
+          KESTRACTL_TOKEN: ${{ secrets.KESTRA_TOKEN_PROD }}
+        run: kestractl flows deploy "${FLOWS_DIR}" --namespace <PROD_NAMESPACE> --override --fail-fast --output json
+```
+
+**Notes**
+- Single environment? Keep `validate` + one `deploy` job, drop the rest.
+- Deploy on tags instead of `main`: use `on: push: tags: ["v*"]` and
+  `if: startsWith(github.ref, 'refs/tags/')`.
+- To also remove flows deleted from the repo, replace `flows deploy` with
+  `kestractl flows namespace-sync <NAMESPACE> "${FLOWS_DIR}" --delete --override`
+  — only when the pipeline fully owns that namespace.
+- Namespace files: add `kestractl nsfiles upload <NAMESPACE> ./<NSFILES_DIR> <REMOTE_PATH> --override` (see `kestra-ops` `references/commands.md`).
+
+---
+
+## Template B — official Kestra actions
+
+`.github/workflows/kestra-cicd.yml`
+
+```yaml
+name: Kestra CI/CD
+
+on:
+  pull_request:
+    paths: ["<FLOWS_DIR>/**"]
+  push:
+    branches: ["<MAIN_BRANCH>"]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kestra-io/github-actions/validate-flows@main
+        with:
+          directory: <FLOWS_DIR>
+          server: ${{ secrets.KESTRA_HOST }}
+          tenant: <TENANT>                       # "main" for OSS default
+          apiToken: ${{ secrets.KESTRA_TOKEN }}  # EE; or user/password for OSS
+          # user: ${{ secrets.KESTRA_USERNAME }}
+          # password: ${{ secrets.KESTRA_PASSWORD }}
+
+  deploy-production:
+    if: github.ref == 'refs/heads/<MAIN_BRANCH>'
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production          # required reviewers = the manual gate
+    steps:
+      - uses: actions/checkout@v4
+      - uses: kestra-io/github-actions/deploy-flows@main
+        with:
+          directory: <FLOWS_DIR>
+          namespace: <PROD_NAMESPACE>           # omit to keep each flow's own namespace
+          override: "true"
+          server: ${{ secrets.KESTRA_HOST_PROD }}
+          tenant: <TENANT>
+          apiToken: ${{ secrets.KESTRA_TOKEN_PROD }}
+```
+
+For offline validation with no reachable instance, use the legacy
+`kestra-io/kestra-validate-action` instead of `validate-flows`.

--- a/skills/kestra-cicd/references/gitlab-ci.md
+++ b/skills/kestra-cicd/references/gitlab-ci.md
@@ -1,0 +1,82 @@
+# GitLab CI — Kestra CI/CD
+
+Raw `kestractl` (no official GitLab component). Replace every `<PLACEHOLDER>`.
+Create the variables under **Settings → CI/CD → Variables**, all **Masked**, and
+the environment-scoped ones **Protected** (available only on the protected branch).
+
+`.gitlab-ci.yml`
+
+```yaml
+stages: [validate, deploy-staging, deploy-production]
+
+variables:
+  KESTRACTL_VERSION: "<KESTRACTL_VERSION>"   # e.g. 1.18.1 — pin it
+  FLOWS_DIR: "<FLOWS_DIR>"                    # e.g. flows
+
+.install_kestractl: &install_kestractl
+  - curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh
+      | VERSION="${KESTRACTL_VERSION}" INSTALL_DIR="${CI_PROJECT_DIR}/.bin" bash
+  - export PATH="${CI_PROJECT_DIR}/.bin:${PATH}"
+
+validate:
+  stage: validate
+  image: alpine:3.20
+  before_script:
+    - apk add --no-cache curl bash
+    - *install_kestractl
+  script:
+    - kestractl flows validate "${FLOWS_DIR}" --output json
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == "<MAIN_BRANCH>"
+  variables:
+    KESTRACTL_HOST: $KESTRA_HOST
+    KESTRACTL_TENANT: $KESTRA_TENANT
+    KESTRACTL_TOKEN: $KESTRA_TOKEN            # EE
+    # KESTRACTL_USERNAME: $KESTRA_USERNAME    # OSS basic auth
+    # KESTRACTL_PASSWORD: $KESTRA_PASSWORD
+
+deploy-staging:
+  stage: deploy-staging
+  image: alpine:3.20
+  environment: { name: staging }
+  before_script:
+    - apk add --no-cache curl bash
+    - *install_kestractl
+  script:
+    - kestractl flows deploy "${FLOWS_DIR}" --namespace <STAGING_NAMESPACE> --override --fail-fast --output json
+  rules:
+    - if: $CI_COMMIT_BRANCH == "<MAIN_BRANCH>"
+  variables:
+    KESTRACTL_HOST: $KESTRA_HOST
+    KESTRACTL_TENANT: $KESTRA_TENANT
+    KESTRACTL_TOKEN: $KESTRA_TOKEN
+
+deploy-production:
+  stage: deploy-production
+  image: alpine:3.20
+  environment: { name: production }
+  before_script:
+    - apk add --no-cache curl bash
+    - *install_kestractl
+  script:
+    - kestractl flows deploy "${FLOWS_DIR}" --namespace <PROD_NAMESPACE> --override --fail-fast --output json
+  rules:
+    - if: $CI_COMMIT_BRANCH == "<MAIN_BRANCH>"
+      when: manual                            # the production gate
+  allow_failure: false
+  variables:
+    KESTRACTL_HOST: $KESTRA_HOST_PROD
+    KESTRACTL_TENANT: $KESTRA_TENANT_PROD
+    KESTRACTL_TOKEN: $KESTRA_TOKEN_PROD
+```
+
+**Notes**
+- Single environment? Keep `validate` + one `deploy` job.
+- Deploy on tags: `if: $CI_COMMIT_TAG` instead of the branch rule.
+- Delete-on-remove GitOps: swap `flows deploy` for
+  `kestractl flows namespace-sync <NAMESPACE> "${FLOWS_DIR}" --delete --override`
+  — only when the pipeline fully owns that namespace.
+- If you use a container image that already has `curl`/`bash`, drop the `apk add`.
+- Namespace files: add a `kestractl nsfiles upload …` step (see `kestra-ops`
+  `references/commands.md`).

--- a/skills/kestra-flow-hardening/SKILL.md
+++ b/skills/kestra-flow-hardening/SKILL.md
@@ -200,6 +200,10 @@ Do not restate — reuse the `kestra-flow` skill's rules so they don't drift:
 - No hardcoded secrets / credentials — use `inputs` of type `SECRET` or `{{ secret('...') }}`.
 - Quoting — prefer double quotes; single quotes inside when needed.
 - Structural preservation — touch only the relevant part; preserve `id` / `namespace`.
+- Resolving plugins and backends — when a finding recommends a task runner, storage,
+  secret manager, log shipper, or replacement plugin, resolve its FQCN and check
+  version compatibility via the MCP tools per `kestra-flow`'s
+  *Resolving plugins and backends* section. Never name a plugin from memory.
 
 ## Example prompts
 

--- a/skills/kestra-flow-hardening/SKILL.md
+++ b/skills/kestra-flow-hardening/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kestra-flow-hardening
-description: Audit one or more existing Kestra flows and add production-hardening controls — retries, timeouts, concurrency limits, error/finally/afterExecution handlers, SLAs, checks, and idempotency guards. Produces a severity-ranked findings report, then applies confirmed edits. Use when users ask to harden, audit, review, or make a flow more production-ready, resilient, or idempotent — not for authoring new flows (use kestra-flow).
-compatibility: Requires curl and network access to https://api.kestra.io/v1/plugins/schemas/flow. No Kestra instance required.
+description: Audit one or more existing Kestra flows and add production-hardening controls — retries, timeouts, concurrency limits, error/finally/afterExecution handlers, SLAs, checks, and idempotency guards. Also diagnoses flow/execution failures grounded in official docs. Produces a severity-ranked findings report, then applies confirmed edits. Use when users ask to harden, audit, review, or make a flow more production-ready, resilient, or idempotent, or to explain why a flow/execution failed — not for authoring new flows (use kestra-flow).
+compatibility: Requires the Kestra MCP server (`mcp__kestra__*` tools). No Kestra instance, and no multi-megabyte schema download, required.
 ---
 
 # Kestra Flow Hardening Skill
@@ -14,10 +14,14 @@ This is the **auditing** counterpart to the sibling skills:
 | Skill | Owns |
 |-------|------|
 | `kestra-flow` | **Authoring** — create / modify / debug flow YAML from intent |
-| **`kestra-flow-hardening`** | **Auditing** — find gaps, recommend + apply guardrails |
+| **`kestra-flow-hardening`** | **Auditing & diagnosis** — find gaps, recommend + apply guardrails; explain failures |
 | `kestra-ops` | **Operating** — validate / deploy / run via `kestractl` |
 
 Hand off to `kestra-flow` for "build a new flow" and to `kestra-ops` for "validate / deploy this".
+
+Two modes: **audit** (proactive — "harden this", Steps 1–8 below) and **troubleshoot**
+(reactive — "why did this fail?", see *Troubleshoot mode*). Both ground every claim
+in the same MCP tools.
 
 ## When to use
 
@@ -26,6 +30,11 @@ Trigger on requests to **harden, audit, review, or make production-ready / resil
 - "Audit my flow — what's missing for reliability?"
 - "Add retries, timeouts, and error handling to this flow."
 - "Review this namespace's flows for resilience gaps."
+
+…or to **diagnose a failure** (troubleshoot mode):
+- "This execution failed with `<error>` — why?"
+- "Why doesn't `{{ trigger.date }}` resolve in my flow?"
+- "My retry block is being rejected on deploy."
 
 Do **not** use this skill to author a brand-new flow from a description — that is `kestra-flow`.
 
@@ -40,15 +49,22 @@ Do **not** use this skill to author a brand-new flow from a description — that
 
 ## Workflow
 
-### Step 1 — Fetch the flow schema (authoritative)
+### Step 1 — Ground in the schema (authoritative, on demand)
 
-```bash
-curl -s https://api.kestra.io/v1/plugins/schemas/flow
-```
+All grounding goes through the `mcp__kestra__*` tools — no bulk schema fetch. If those
+tools are unavailable, stop and tell the user this skill requires the Kestra MCP server.
 
-Read the raw JSON. The schema is the **source of truth** for which properties and types
-exist in the target version. Never recommend a property absent from the schema — this is
-what catches version traps such as `retry.maxAttempt` (pre-0.24) vs `retry.maxAttempts`.
+- **Flow structure** — `mcp__kestra__list_doc_children` (`path: "docs/workflow-components"`)
+  for the component index and its version gates, then `mcp__kestra__get_doc` for the
+  components in play (e.g. `.../retries`, `.../errors`, `.../concurrency`, `.../sla`),
+  passing `version` when the user gave a Kestra version.
+- **Task / trigger types and properties** — `mcp__kestra__task_schema` with `cls: <FQCN>`
+  for every type referenced. This is the **source of truth** for which properties exist
+  in the target version; it is what catches version traps such as `retry.maxAttempt`
+  (pre-0.24) vs `retry.maxAttempts`.
+
+Never recommend (or accept) a property that is not in the `task_schema` / `get_doc`
+result for the target version.
 
 ### Step 2 — Confirm scope and context
 
@@ -115,8 +131,8 @@ toward better-maintained flows, not to gate anything.
   workloads, `Script` for quick iteration.
 - **Scripts duplicating plugin functionality → native plugin.** When a script reimplements
   something a Kestra plugin already does, recommend the native task — less custom code to
-  maintain. Pattern-match common usage to plugin families and **verify the task exists in the
-  fetched schema before naming it**:
+  maintain. Pattern-match common usage to plugin families and **verify the task exists via
+  `mcp__kestra__task_schema` before naming it**:
   - `curl` / `wget` / `requests` → `io.kestra.plugin.core.http.Request` / `Download`
   - `psql` / `mysql` / `sqlite3` → the matching JDBC plugin (`io.kestra.plugin.jdbc.*`)
   - `aws` / `gcloud` / `az` CLI → the cloud plugins (`io.kestra.plugin.aws|gcp|azure.*`)
@@ -171,7 +187,7 @@ Format (findings numbered **globally** so the user can select by number):
   Move the ~40-line script into a Namespace File and call it from a `Commands` task
   (versioned, testable, editable in the Code Editor).
 - **Script duplicates a plugin** — `tasks.fetch`
-  This `curl` shell task can be `io.kestra.plugin.core.http.Request` (verified in schema).
+  This `curl` shell task can be `io.kestra.plugin.core.http.Request` (verified via `task_schema`).
 
 ---
 Summary: N Critical · N High · N Medium · N Low · N Advisory
@@ -189,9 +205,59 @@ Reply with the numbers to apply (e.g. `1,4,7`), `all`, or `none`.
 On `apply 1,4,7` / `all`:
 - **Surgical, structure-preserving edits.** Touch only the relevant tasks / blocks. Preserve root `id` / `namespace`, task ordering, and comments. Never restructure unrelated parts.
 - **File input** → edit the file in place. **Pasted YAML** → return the modified YAML. **Batch** → edit each file.
-- **Re-validate** every edit against the fetched schema (properties and types must exist).
+- **Re-validate** every edit against `mcp__kestra__task_schema` / `get_doc` (properties and types must exist in the target version).
 - The initial number-selection **is** informed consent (the report already stated each risk / caveat) — do not re-prompt per finding, but show the diff as you apply it.
 - Suggest `kestractl flow validate` (via `kestra-ops`) as an optional final gate; do not require a live instance.
+
+## Troubleshoot mode (reactive)
+
+Use this path when the input is a **failure** — an error message, a failed task log,
+a rejected deploy, or a "why doesn't X work" question — rather than a request to
+audit. It is the same schema discipline as the audit, run against a concrete symptom.
+
+Reason from the docs and schema, not from memory — Kestra changes fast enough that a
+training-data answer is a real risk.
+
+### T1 — Capture the symptom and context
+
+- The exact error text / stack / rejected snippet, and which task or property it names.
+- **Kestra version and edition.** Ask if unknown; default latest OSS. Version is
+  load-bearing here — most traps are "this changed in version N".
+- The relevant flow YAML fragment if available.
+
+### T2 — Ground the diagnosis
+
+1. `mcp__kestra__search_docs` with `q` = key terms from the error, and `version` set
+   to the user's Kestra version. Fetch the top hit(s) with `mcp__kestra__get_doc`
+   (`version` pinned).
+2. For any task / trigger / property the error references, call
+   `mcp__kestra__task_schema` (`cls: <FQCN>`) and check whether the property exists,
+   is spelled correctly, is deprecated (`$deprecated`), or moved.
+3. Check `references/troubleshooting.md` for the failure signature — it maps common
+   symptoms to the doc page and the schema check that confirms them. It is a starting
+   map, not a substitute for step 1–2 against the running version.
+4. For a "not found" plugin/type, confirm availability with `mcp__kestra__versions`
+   (see `kestra-flow`'s *Resolving plugins and backends*).
+
+### T3 — Report
+
+```
+## Diagnosis: <one-line root cause>
+
+Symptom: <the error, trimmed>
+Root cause: <what's actually wrong>, confirmed against
+  <doc page> (v<X.Y>) and `task_schema` for <FQCN>.
+Fix: <the minimal change> 
+  <before / after snippet>
+Notes: <version/edition caveats, related traps to check>
+```
+
+- Cite the doc page and version you used. If the docs and the observed behavior
+  disagree, say so rather than guessing.
+- If the fix is a flow edit and the user wants it applied, hand off to the audit
+  path's Step 8 (surgical, schema-re-validated edit).
+- If the root cause is operational (bad credentials, instance unreachable, deploy
+  failure), name it and hand off to `kestra-ops`.
 
 ## Shared rules (inherited from `kestra-flow`)
 
@@ -212,3 +278,6 @@ Do not restate — reuse the `kestra-flow` skill's rules so they don't drift:
 - "Review all flows in `./flows/` for resilience gaps and rank them worst-first."
 - "Make this scheduled flow idempotent — it sometimes runs twice." *(idempotency tier judgment)*
 - "Add alerting and an SLA to this business-critical flow."
+- "This execution failed with `Invalid property 'maxAttempt'` — why, and what's the fix?" *(troubleshoot)*
+- "Why is my `{{ trigger.date }}` expression empty at runtime?" *(troubleshoot)*
+- "`kestractl flow validate` rejects my `finally` block on 0.20 — explain." *(troubleshoot)*

--- a/skills/kestra-flow-hardening/references/hardening-patterns.md
+++ b/skills/kestra-flow-hardening/references/hardening-patterns.md
@@ -1,11 +1,11 @@
 # Hardening Patterns Reference
 
 Canonical, copy-pasteable YAML for each hardening construct, with **when to apply** and
-**when NOT to**. Validate every property against the live schema
-(`curl -s https://api.kestra.io/v1/plugins/schemas/flow`) before recommending — versions
-differ, and a property absent from the schema must not be used.
+**when NOT to**. Validate every property via `mcp__kestra__task_schema` (`cls: <FQCN>`)
+and, for flow-level shape, `mcp__kestra__get_doc` (`version` pinned) before recommending —
+versions differ, and a property absent from the schema must not be used.
 
-Version / edition gates (verify against the fetched schema):
+Version / edition gates (verify via `task_schema` / `get_doc` for the target version):
 `concurrency` ≥ 0.13 · `sla` ≥ 0.20 · `finally` ≥ 0.21 · `afterExecution` ≥ 0.22 ·
 `checks` ≥ 1.2 · `retry.maxAttempts` (was `maxAttempt` before 0.24) ·
 `system.correlationId` idempotency via the executions search API is **Enterprise-only**.
@@ -345,7 +345,7 @@ the Code Editor, and reusable across flows. Pass values via `env`.
 ### Script duplicating plugin functionality → native plugin
 
 When a script reimplements something a plugin already does, recommend the native task — but
-**verify the task exists in the fetched schema before naming it**.
+**verify the task exists via `mcp__kestra__task_schema` before naming it**.
 
 ```yaml
 # BEFORE — shell task wrapping curl
@@ -362,7 +362,7 @@ When a script reimplements something a plugin already does, recommend the native
   uri: https://api.example.com/data
 ```
 
-Common mappings (confirm against the schema / plugin list):
+Common mappings (confirm via `task_schema` / `list_plugins`):
 
 | Scripted with | Prefer native plugin |
 |---------------|----------------------|

--- a/skills/kestra-flow-hardening/references/troubleshooting.md
+++ b/skills/kestra-flow-hardening/references/troubleshooting.md
@@ -1,0 +1,97 @@
+# Troubleshooting reference
+
+A starting map from common Kestra failure signatures to the doc page that explains
+them and the schema check that confirms the cause. **Not exhaustive, and not a
+substitute for checking the running version** — always:
+
+1. `mcp__kestra__search_docs` with `q` = key terms from the error and `version` set
+   to the user's Kestra version.
+2. `mcp__kestra__get_doc` for the top hit(s), `version` pinned.
+3. `mcp__kestra__task_schema` (`cls: <FQCN>`) for any type the error names — check
+   the property exists, is spelled right, and is not `$deprecated`.
+
+Kestra pins docs per version, so a page that describes the fix as a "migration"
+tells you exactly which release introduced the change.
+
+---
+
+## Renamed / moved / removed properties (version traps)
+
+These surface as `Invalid property '<x>'`, `Unknown property`, schema-validation
+failure on deploy, or a silently ignored setting.
+
+| Symptom | Cause / change | Doc page | Confirm |
+|---------|----------------|----------|---------|
+| `maxAttempt` rejected on `retry` | renamed to `maxAttempts` in 0.24 | `docs/migration-guide/v0.24.0/retries-maxattempts` | `task_schema` for the task → `retry.maxAttempts` |
+| `name:` rejected on an input | inputs use `id:` since 0.15 | `docs/migration-guide/v0.15.0/inputs-name` | `get_doc docs/workflow-components/inputs` |
+| `runner:` ignored / rejected on a script task | replaced by `taskRunner:` in 0.18 | `docs/migration-guide/v0.18.0/runners` | `task_schema` → `taskRunner` |
+| `scheduleConditions` rejected on Schedule trigger | renamed to `conditions` in 0.15 | `docs/migration-guide/v0.15.0/schedule-conditions` | `task_schema` for `io.kestra.plugin.core.trigger.Schedule` |
+| `*Condition` type not found | conditions renamed in 0.20 | `docs/migration-guide/v0.20.0/conditions-renamed` | `list_triggers` / `task_schema` |
+| `outputDir` / `LocalFiles` not working | deprecated in 0.17 — use `outputFiles` / `inputFiles` | `docs/migration-guide/v0.17.0/local-files` | `docs/scripts/input-output-files` |
+| `io.kestra.core.tasks.*` type not found | core plugins renamed to `io.kestra.plugin.core.*` in 0.17 | `docs/migration-guide/v0.17.0/renamed-plugins` | `search` (PLUGINS) for the new FQCN |
+| `permissions:` rejected on `PurgeAuditLogs` | renamed to `resources:` in 1.0 | `docs/migration-guide/v1.0.0/purge-audit-logs` | `task_schema` for the task |
+| `autocommit` rejected on a JDBC Query | removed from query tasks in 0.23 | `docs/migration-guide/v0.23.0/jdbc-autocommit` | `task_schema` for the JDBC task |
+| Flow won't save — id like `executions`, `flows`, … | reserved keywords can't be flow ids since 1.0 | `docs/migration-guide/v1.0.0/reserved-flow-ids` | — |
+
+## Feature not available in this version
+
+Surfaces as an unknown top-level key or a task type that doesn't resolve.
+
+| Property / type | Available from | Doc |
+|-----------------|---------------|-----|
+| `concurrency` | 0.13 | `docs/workflow-components/concurrency` |
+| `sla` | 0.20 | `docs/workflow-components/sla` |
+| `finally` | 0.21 | `docs/workflow-components/finally` |
+| `afterExecution` | 0.22 | `docs/workflow-components/afterexecution` |
+| `checks` | 1.2 | `docs/workflow-components/checks` |
+| Realtime triggers | 0.17 | `docs/workflow-components/triggers/realtime-trigger` |
+
+Check the version gate in `list_doc_children docs/workflow-components` metadata before
+recommending any of these.
+
+## Expressions / Pebble
+
+| Symptom | Likely cause | Doc |
+|---------|--------------|-----|
+| Expression renders literally / not resolved | non-recursive rendering since 0.14 — nested `{{ }}` isn't re-evaluated; use the `render()` function | `docs/migration-guide/v0.14.0/recursive-rendering`, `docs/expressions/functions/rendering` |
+| `{{ trigger.<x> }}` is empty at runtime | that output isn't declared by the trigger type, or the flow was run manually (no trigger context) | per-trigger page under `docs/workflow-components/triggers/`, plus `task_schema` for the trigger's `outputsSchema` |
+| Numeric comparison always false | value is a string — apply `| number` first | `docs/expressions` |
+| Date arithmetic wrong / errors | use `dateAdd` / `date` filters, not string math | `docs/expressions/filters/dates` |
+| `kv('<key>')` fails instead of returning null | `kv()` errors on missing keys since 0.22 — pass a default or guard | `docs/migration-guide/v0.22.0/kv-error-on-missing` |
+
+## Inputs
+
+| Symptom | Cause | Doc |
+|---------|-------|-----|
+| Input default not applied as expected | defaults are dynamically rendered since 1.0 | `docs/migration-guide/v1.0.0/inputs-defaults-property` |
+| `prefill` behaving unexpectedly | new `prefill` property, breaking change in 1.1 | `docs/migration-guide/v1.1.0/prefill-inputs` |
+| Loose `STRING` where a set is expected | tighten to `SELECT` / `ENUM` (also a hardening finding) | `docs/workflow-components/inputs` |
+
+## Scripts
+
+| Symptom | Cause | Doc |
+|---------|-------|-----|
+| Script can't see an uploaded file | `namespaceFiles.enabled: true` + `include` needed to mount, or use `inputFiles` | `docs/scripts/input-output-files`, `docs/scripts/working-directory` |
+| Output file not captured | must be listed in `outputFiles` and written to the working dir | `docs/scripts/input-output-files` |
+| Task WARNING on stderr no longer happens | WARNING-on-ERROR-logs removed for script tasks in 0.23 | `docs/migration-guide/v0.23.0/script-warnings` |
+| `Commands` vs `Script` confusion | `Commands` mounts files / runs a CLI; `Script` takes inline code | `docs/scripts/commands-vs-scripts` |
+
+## Flow structure & execution
+
+| Symptom | Cause | Doc |
+|---------|-------|-----|
+| Subflow outputs not visible to parent | outputs behavior changed in 0.15 — subflow must declare `outputs` | `docs/migration-guide/v0.15.0/subflow-outputs`, `docs/workflow-components/subflows` |
+| `ForEachItem` iteration index off by one | iteration starts at 0 since 1.1 | `docs/migration-guide/v1.1.0/foreach-item` |
+| `LoopUntil` polling too fast/slow | `checkFrequency` defaults changed in 0.23 | `docs/migration-guide/v0.23.0/loop-until-defaults` |
+| Concurrency `behavior` seems ignored on a triggered flow | trigger holds a lock — new trigger executions are skipped, not queued; pair with trigger `allowConcurrent` | `docs/workflow-components/concurrency` |
+| `errors` / `finally` / `afterExecution` doing the wrong thing | they fire at different points — pick by intent | `docs/workflow-components/errors`, `.../finally`, `.../afterexecution` |
+| Retry loops but never delays | `retry.interval` ≥ `retry.maxDuration` | `docs/workflow-components/retries` |
+
+## Operational (hand off to `kestra-ops`)
+
+| Symptom | Cause | Doc |
+|---------|-------|-----|
+| API calls / CLI rejected on 0.23+ OSS | multitenancy is mandatory — a tenant is required | `docs/migration-guide/v0.23.0` |
+| CLI auth fails on 0.24+ OSS | basic auth is now required | `docs/migration-guide/v0.24.0/basic-authentication` |
+| `KESTRA_<x>` env vars not picked up | flow-scoped env prefix changed `KESTRA_` → `ENV_` in 0.23 | `docs/migration-guide/v0.23.0/default-env-prefix` |
+| Secret not resolving | secret backend not configured, or wrong name — `{{ secret('NAME') }}` | `docs/concepts/secret`, `docs/how-to-guides/secrets` |

--- a/skills/kestra-flow/SKILL.md
+++ b/skills/kestra-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kestra-flow
-description: Generate, modify, or debug Kestra Flow YAML by fetching the live flow schema and applying the same guardrails used by the Kestra AI Copilot. Use when users ask to create, write, update, or fix a Kestra flow.
-compatibility: Requires curl and network access to https://api.kestra.io/v1/plugins/schemas/flow. No Kestra instance required.
+description: Generate, modify, or debug Kestra Flow YAML grounded in the live schema via the Kestra MCP server, applying the same guardrails used by the Kestra AI Copilot. Use when users ask to create, write, update, or fix a Kestra flow.
+compatibility: Requires the Kestra MCP server (`mcp__kestra__*` tools). No Kestra instance, and no multi-megabyte schema download, required.
 ---
 
 # Kestra Flow Skill
@@ -19,21 +19,32 @@ Use this skill when the request includes:
 
 - A description of the desired flow behavior
 - Namespace (and tenant ID if applicable)
+- Kestra version, if known — used to pin `get_doc` lookups; default to latest
 - Existing flow YAML if the request is a modification
 
 ## Workflow
 
-### Step 1 — Fetch the flow schema
+All schema grounding goes through the `mcp__kestra__*` tools — load only what the
+flow needs, when it needs it. There is no bulk schema fetch. If those tools are not
+available, stop and tell the user this skill requires the Kestra MCP server.
 
-Fetch the full schema with `curl` and read it directly — do not pipe it through any interpreter:
+### Step 1 — Load flow structure (on demand)
 
-```bash
-curl -s https://api.kestra.io/v1/plugins/schemas/flow
-```
+The flow-level shape (`id`, `namespace`, `inputs`, `variables`, `tasks`, `triggers`,
+`errors`, `finally`, `afterExecution`, `pluginDefaults`, `concurrency`, `sla`,
+`checks`, `disabled`, `labels`, `retry`) comes from the docs, pinned to the user's
+Kestra version:
 
-Read the raw JSON output to validate every type, property name, and structure used in the output. Do not generate anything before the schema is available.
+- `mcp__kestra__list_doc_children` with `path: "docs/workflow-components"` — the
+  component index; each entry's metadata carries the version gate (e.g. `checks`
+  `>= 1.2.0`, `sla` `>= 0.20.0`).
+- `mcp__kestra__get_doc` for **only** the components this flow uses (e.g.
+  `docs/workflow-components/inputs`, `.../triggers`, `.../errors`, `.../retries`,
+  `.../concurrency`). Pass `version` when the user gave a Kestra version.
 
-### Step 2 — Collect context
+Do not assume a component exists in the target version — check the gate first.
+
+### Step 2 — Collect context and resolve task/trigger types
 
 Identify from the user message or conversation:
 - `id` — flow identifier (preserve if provided)
@@ -41,14 +52,27 @@ Identify from the user message or conversation:
 - Existing flow YAML (for modification requests)
 - Whether this is an **addition / deletion / modification** or a **full rewrite**
 
-### Step 3 — Generate the YAML
+Resolve every task / trigger to a real FQCN — never guess one:
+- `mcp__kestra__search` with `type: "PLUGINS"`, or `mcp__kestra__list_plugins` then
+  `mcp__kestra__plugin_tasks`, to find the class for the intent.
+- For task runners, storage, secret managers, log exporters, or trigger types, use
+  the matching `mcp__kestra__list_*` tool.
 
-Apply all generation rules below, then output raw YAML only.
+### Step 3 — Fetch the per-task schema, then generate
+
+For **every** task and trigger type in the flow, call
+`mcp__kestra__task_schema` with `cls: <FQCN>` and validate every property name,
+enum value, required field, and output reference against it. Do not write a task
+before its `task_schema` is loaded.
+
+Then apply all generation rules below and output raw YAML only.
 
 ## Generation rules
 
 **Schema compliance**
-- Use only task types and properties explicitly defined in the fetched schema. Never invent or guess types or property names.
+- Use only task/trigger types and properties present in the `mcp__kestra__task_schema`
+  response for that type. Never invent or guess types or property names.
+- Use only flow-level properties confirmed via `get_doc` for the target version.
 - Property keys must be unique within each task or block.
 
 **Structural preservation**
@@ -90,7 +114,8 @@ Apply all generation rules below, then output raw YAML only.
 - Prefer double quotes; use single quotes inside double-quoted strings when needed.
 
 **Error handling**
-- If the request cannot be fulfilled using only schema-defined types and properties, output exactly:
+- If the request cannot be fulfilled using only types and properties confirmed via
+  `mcp__kestra__task_schema` / `get_doc`, output exactly:
   ```
   I cannot generate a valid Kestra Flow YAML for this request based on the available schema.
   ```

--- a/skills/kestra-flow/SKILL.md
+++ b/skills/kestra-flow/SKILL.md
@@ -78,11 +78,8 @@ Identify from the user message or conversation:
 - Existing flow YAML (for modification requests)
 - Whether this is an **addition / deletion / modification** or a **full rewrite**
 
-Resolve every task / trigger to a real FQCN — never guess one:
-- `mcp__kestra__search` with `type: "PLUGINS"`, or `mcp__kestra__list_plugins` then
-  `mcp__kestra__plugin_tasks`, to find the class for the intent.
-- For task runners, storage, secret managers, log exporters, or trigger types, use
-  the matching `mcp__kestra__list_*` tool.
+Resolve every task / trigger / backend to a real FQCN — never guess one. See
+[Resolving plugins and backends](#resolving-plugins-and-backends) below.
 
 ### Step 4 — Fetch the per-task schema, then generate
 
@@ -92,6 +89,35 @@ enum value, required field, and output reference against it. Do not write a task
 before its `task_schema` is loaded.
 
 Then apply all generation rules below and output raw YAML only.
+
+## Resolving plugins and backends
+
+Never type a plugin, task, or backend FQCN from memory — the plugin ecosystem
+changes fast. Resolve it through the MCP tools first, then validate with
+`task_schema` (Step 4). This section is also referenced by `kestra-flow-hardening`
+when auditing an existing flow's plugin choices.
+
+**Requirement → tool.** Recommend only FQCNs returned by these:
+
+| The flow needs… | Tool |
+|-----------------|------|
+| A task for some intent | `mcp__kestra__search` (`type: "PLUGINS"`) or `mcp__kestra__list_plugins` → `mcp__kestra__plugin_tasks` |
+| A task runner (Kubernetes, AWS Batch, GCP Batch, Docker, …) | `mcp__kestra__list_task_runners` |
+| An internal storage backend (S3, GCS, Azure Blob, MinIO, …) | `mcp__kestra__list_storages` |
+| A secret manager backend (Vault, AWS/GCP/Azure, 1Password, CyberArk, …) | `mcp__kestra__list_secret_managers` |
+| A log shipper / exporter | `mcp__kestra__list_log_exporters` |
+| A trigger type | `mcp__kestra__list_triggers` |
+
+**Check version compatibility before recommending.**
+- `mcp__kestra__versions` (optionally `plugin: <name>`) — the plugin versions
+  available on the instance. A plugin absent from the output may not be installed —
+  say so rather than assuming it is.
+- `mcp__kestra__plugin_versions` with the repo name (e.g. `plugin-aws`) — full
+  release history and the Kestra version each release targets. Use it to flag a
+  compatibility gap against the user's Kestra version.
+
+**Prefer non-deprecated.** If `task_schema` marks a type or property `$deprecated`,
+use the current replacement and note the change.
 
 ## Generation rules
 

--- a/skills/kestra-flow/SKILL.md
+++ b/skills/kestra-flow/SKILL.md
@@ -29,6 +29,10 @@ All schema grounding goes through the `mcp__kestra__*` tools — load only what 
 flow needs, when it needs it. There is no bulk schema fetch. If those tools are not
 available, stop and tell the user this skill requires the Kestra MCP server.
 
+> Security: this skill does not `curl` or otherwise fetch a live external schema
+> document to steer generation. Grounding comes only from the Kestra MCP server's
+> typed, scoped tool calls — no unverified third-party payload in the loop.
+
 ### Step 1 — Start from a blueprint when one fits
 
 Kestra ships production-vetted flow templates. Reusing one beats generating from a

--- a/skills/kestra-flow/SKILL.md
+++ b/skills/kestra-flow/SKILL.md
@@ -20,6 +20,7 @@ Use this skill when the request includes:
 - A description of the desired flow behavior
 - Namespace (and tenant ID if applicable)
 - Kestra version, if known — used to pin `get_doc` lookups; default to latest
+- Kestra edition (OSS / EE), if known — gates EE-only blueprints
 - Existing flow YAML if the request is a modification
 
 ## Workflow
@@ -28,7 +29,32 @@ All schema grounding goes through the `mcp__kestra__*` tools — load only what 
 flow needs, when it needs it. There is no bulk schema fetch. If those tools are not
 available, stop and tell the user this skill requires the Kestra MCP server.
 
-### Step 1 — Load flow structure (on demand)
+### Step 1 — Start from a blueprint when one fits
+
+Kestra ships production-vetted flow templates. Reusing one beats generating from a
+blank schema — fewer invented task combinations.
+
+1. `mcp__kestra__blueprints` with `query` derived from the user's intent. Narrow with
+   `tags` and/or `types` (task-type FQCNs) once known — resolve FQCNs the same way as
+   Step 3.
+2. Judge the results by `title`, `description`, and `includedTasks`. A blueprint is a
+   good starting point only if it covers most of the requested behavior.
+   - **EE gate:** if a candidate has `ee: true` and the user is on OSS, do not offer
+     it — say an EE-only blueprint exists but was skipped. If the edition is unknown,
+     ask before using an `ee: true` blueprint.
+3. For the closest match, `mcp__kestra__get_blueprint_flow` with its `id` to get the
+   full YAML, then **adapt** rather than accept as-is:
+   - set `id` / `namespace` to the user's values
+   - replace any inline credentials, tokens, or hostnames with `{{ secret('...') }}`
+     or `SECRET`-typed `inputs`
+   - remove tasks unrelated to the request; tune parameters to match it
+4. If no blueprint is a close fit, skip to Step 2 and generate from the schema. Do
+   **not** force-fit a loosely related blueprint.
+
+Whether adapted from a blueprint or generated fresh, the result still passes through
+Step 4 schema validation — blueprints can lag the running version's schema.
+
+### Step 2 — Load flow structure (on demand)
 
 The flow-level shape (`id`, `namespace`, `inputs`, `variables`, `tasks`, `triggers`,
 `errors`, `finally`, `afterExecution`, `pluginDefaults`, `concurrency`, `sla`,
@@ -44,7 +70,7 @@ Kestra version:
 
 Do not assume a component exists in the target version — check the gate first.
 
-### Step 2 — Collect context and resolve task/trigger types
+### Step 3 — Collect context and resolve task/trigger types
 
 Identify from the user message or conversation:
 - `id` — flow identifier (preserve if provided)
@@ -58,7 +84,7 @@ Resolve every task / trigger to a real FQCN — never guess one:
 - For task runners, storage, secret managers, log exporters, or trigger types, use
   the matching `mcp__kestra__list_*` tool.
 
-### Step 3 — Fetch the per-task schema, then generate
+### Step 4 — Fetch the per-task schema, then generate
 
 For **every** task and trigger type in the flow, call
 `mcp__kestra__task_schema` with `cls: <FQCN>` and validate every property name,

--- a/skills/kestra-ops/SKILL.md
+++ b/skills/kestra-ops/SKILL.md
@@ -13,7 +13,7 @@ loaded on demand — pull in only what the current request needs:
 
 | Load when the request involves | Reference |
 |--------------------------------|-----------|
-| Any command beyond the cheat-sheet below, or a command group not shown here (`triggers`, `kv`, `plugins`, `workers`, `blueprints`, EE resources) | [`references/commands.md`](references/commands.md) |
+| Any command beyond the cheat-sheet below — the full `kestractl` surface (`flows`, `executions`, `triggers`, `namespaces`, `kv`, `nsfiles`, `plugins`, `workers`, `logs`, `secrets`, `server`, `blueprints`, and EE-only groups), pinned to a kestractl release | [`references/commands.md`](references/commands.md) |
 | Deciding *how* to run an operation — discovery vs. write ordering, `--wait` vs. poll, bulk vs. loop, guardrails, failure handling, and the ops report format | [`references/workflow.md`](references/workflow.md) |
 
 ## When to use

--- a/skills/kestra-ops/SKILL.md
+++ b/skills/kestra-ops/SKILL.md
@@ -14,7 +14,7 @@ loaded on demand — pull in only what the current request needs:
 | Load when the request involves | Reference |
 |--------------------------------|-----------|
 | Any command beyond the cheat-sheet below — the full `kestractl` surface (`flows`, `executions`, `triggers`, `namespaces`, `kv`, `nsfiles`, `plugins`, `workers`, `logs`, `secrets`, `server`, `blueprints`, and EE-only groups), pinned to a kestractl release | [`references/commands.md`](references/commands.md) |
-| Deciding *how* to run an operation — edition (OSS/EE) awareness, per-group decision notes, discovery vs. write ordering, `--wait` vs. poll, `*-by-query` vs. loop, revision-awareness, guardrails, and the ops report format | [`references/workflow.md`](references/workflow.md) |
+| Deciding *how* to run an operation — edition (OSS/EE) awareness, per-group decision notes, discovery vs. write ordering, `--wait` vs. poll, `*-by-query` vs. loop, revision-awareness, failure handling, guardrails, and the ops report format | [`references/workflow.md`](references/workflow.md) |
 | `kestractl` is missing, or older than this skill expects | [`scripts/ensure-kestractl.sh`](scripts/ensure-kestractl.sh) — dry-run check + on-request install/upgrade |
 
 ## When to use

--- a/skills/kestra-ops/SKILL.md
+++ b/skills/kestra-ops/SKILL.md
@@ -8,6 +8,14 @@ compatibility: Requires kestractl, network access to the Kestra API, and valid t
 
 Use this skill to perform day-to-day Kestra operations with `kestractl`.
 
+This SKILL.md is the entry point. Detailed material lives in `references/` and is
+loaded on demand — pull in only what the current request needs:
+
+| Load when the request involves | Reference |
+|--------------------------------|-----------|
+| Any command beyond the cheat-sheet below, or a command group not shown here (`triggers`, `kv`, `plugins`, `workers`, `blueprints`, EE resources) | [`references/commands.md`](references/commands.md) |
+| Deciding *how* to run an operation — discovery vs. write ordering, `--wait` vs. poll, bulk vs. loop, guardrails, failure handling, and the ops report format | [`references/workflow.md`](references/workflow.md) |
+
 ## When to use
 
 Use this skill when the request includes:
@@ -27,7 +35,7 @@ Use this skill when the request includes:
 
 - `kestractl` is installed and executable
 - Access token and tenant are available
-- A valid context exists in `~/.kestractl/config.yaml` or values are provided via env vars/flags
+- A valid context exists in `~/.kestractl/config.yaml`, or values are provided via env vars / flags
 
 ## Configuration precedence
 
@@ -46,63 +54,16 @@ kestractl config use dev
 kestractl config show
 ```
 
-## Standard workflow
+## Most common commands
 
-1. Resolve and confirm the target context.
-2. Run read-only discovery first.
-3. Validate artifacts before any deployment.
-4. Execute the requested operation with explicit flags.
-5. Verify outcomes (`--wait` for run operations where needed).
-6. Return a concise ops report with results and follow-up actions.
-
-## Command patterns
-
-Flows:
+The everyday subset — for anything else, load [`references/commands.md`](references/commands.md):
 
 ```bash
 kestractl flows list my.namespace
-kestractl flows get my.namespace my-flow
 kestractl flows validate ./flows/
 kestractl flows deploy ./flows/ --namespace prod.namespace --override --fail-fast
-```
-
-Executions:
-
-```bash
 kestractl executions run my.namespace my-flow --wait
-kestractl executions get 2TLGqHrXC9k8BczKJe5djX
 ```
-
-Namespaces:
-
-```bash
-kestractl namespaces list
-kestractl namespaces list --query my.namespace
-```
-
-Namespace files:
-
-```bash
-kestractl nsfiles list my.namespace --path workflows/ --recursive
-kestractl nsfiles get my.namespace workflows/example.yaml --revision 3
-kestractl nsfiles upload my.namespace ./assets resources --override --fail-fast
-kestractl nsfiles delete my.namespace workflows --recursive
-```
-
-## Guardrails
-
-- Confirm production context before write operations (`deploy`, `upload`, `delete`).
-- Prefer `flows validate` before `flows deploy`.
-- Use `--output json` for scripting and automation reliability.
-- Avoid `--verbose` in shared logs because it can expose credentials.
-- For destructive `nsfiles` actions, confirm path scope and only use `--force` intentionally.
-
-## Response format
-
-- Context used (host, tenant, context name)
-- Commands executed (grouped by read vs write)
-- Results (success/failure and key IDs)
-- Risks, rollback notes, and follow-up actions
 
 ## Example prompts
 

--- a/skills/kestra-ops/SKILL.md
+++ b/skills/kestra-ops/SKILL.md
@@ -14,7 +14,7 @@ loaded on demand — pull in only what the current request needs:
 | Load when the request involves | Reference |
 |--------------------------------|-----------|
 | Any command beyond the cheat-sheet below — the full `kestractl` surface (`flows`, `executions`, `triggers`, `namespaces`, `kv`, `nsfiles`, `plugins`, `workers`, `logs`, `secrets`, `server`, `blueprints`, and EE-only groups), pinned to a kestractl release | [`references/commands.md`](references/commands.md) |
-| Deciding *how* to run an operation — discovery vs. write ordering, `--wait` vs. poll, bulk vs. loop, guardrails, failure handling, and the ops report format | [`references/workflow.md`](references/workflow.md) |
+| Deciding *how* to run an operation — edition (OSS/EE) awareness, per-group decision notes, discovery vs. write ordering, `--wait` vs. poll, `*-by-query` vs. loop, revision-awareness, guardrails, and the ops report format | [`references/workflow.md`](references/workflow.md) |
 
 ## When to use
 
@@ -28,6 +28,7 @@ Use this skill when the request includes:
 
 - Target environment or context (`dev`, `staging`, `prod`)
 - Host URL, tenant, and authentication method (usually token)
+- Kestra edition (OSS / EE) — gates the EE-only command groups; ask once if unknown
 - Namespace, flow ID, execution ID, and/or local file paths
 - Output preference (`table` for human-readable, `json` for automation)
 

--- a/skills/kestra-ops/SKILL.md
+++ b/skills/kestra-ops/SKILL.md
@@ -86,6 +86,14 @@ must be on the line — keep it a `$VAR` reference, never the secret itself.
 
 ## Most common commands
 
+Before the first `kestractl` call in a session, attribute it to this skill (no
+behavior change; lets instance telemetry tell skill-driven CLI use apart from a
+human at the terminal). Skip if `KESTRACTL_TELEMETRY_DISABLED` is set.
+
+```bash
+export KESTRACTL_SKILL_SOURCE=kestra-ops
+```
+
 The everyday subset — for anything else, load [`references/commands.md`](references/commands.md):
 
 ```bash

--- a/skills/kestra-ops/SKILL.md
+++ b/skills/kestra-ops/SKILL.md
@@ -15,6 +15,7 @@ loaded on demand — pull in only what the current request needs:
 |--------------------------------|-----------|
 | Any command beyond the cheat-sheet below — the full `kestractl` surface (`flows`, `executions`, `triggers`, `namespaces`, `kv`, `nsfiles`, `plugins`, `workers`, `logs`, `secrets`, `server`, `blueprints`, and EE-only groups), pinned to a kestractl release | [`references/commands.md`](references/commands.md) |
 | Deciding *how* to run an operation — edition (OSS/EE) awareness, per-group decision notes, discovery vs. write ordering, `--wait` vs. poll, `*-by-query` vs. loop, revision-awareness, guardrails, and the ops report format | [`references/workflow.md`](references/workflow.md) |
+| `kestractl` is missing, or older than this skill expects | [`scripts/ensure-kestractl.sh`](scripts/ensure-kestractl.sh) — dry-run check + on-request install/upgrade |
 
 ## When to use
 
@@ -34,9 +35,20 @@ Use this skill when the request includes:
 
 ## Prerequisites
 
-- `kestractl` is installed and executable
-- Tenant plus one of: an API token, or username/password (basic auth)
-- A valid context exists in `~/.kestractl/config.yaml`, or values are provided via env vars / flags
+- **`kestractl` present and current.** Run [`scripts/ensure-kestractl.sh`](scripts/ensure-kestractl.sh)
+  first — it is a no-op if `kestractl` is on `PATH` and meets the minimum version
+  (`1.16.0`). If it reports missing or stale:
+  1. Show the user the printed **PLAN** and the two install-dir choices — `~/.local/bin`
+     (user home scope) or `<skill>/scripts/bin` (self-contained). Get an explicit OK.
+  2. Re-run with `--install --install-dir <their choice>`. The script uses the official
+     published installer (`curl … install-scripts/install.sh | bash`, which does OS/arch
+     detection + sha256 verification). Never a system path, never `sudo`.
+  3. Surface the resolved `kestractl` version in the ops report.
+- **A connection context.** After a fresh install, or when none exists, **ask** the user
+  whether to add one (don't assume): `kestractl config add <name> <host> <tenant> …
+  --default` — `--username`/`--password` for OSS, `--token` for Enterprise. See
+  Configuration precedence below.
+- Tenant plus one of: an API token, or username/password (basic auth).
 
 ## Configuration precedence
 

--- a/skills/kestra-ops/SKILL.md
+++ b/skills/kestra-ops/SKILL.md
@@ -35,18 +35,18 @@ Use this skill when the request includes:
 ## Prerequisites
 
 - `kestractl` is installed and executable
-- Access token and tenant are available
+- Tenant plus one of: an API token, or username/password (basic auth)
 - A valid context exists in `~/.kestractl/config.yaml`, or values are provided via env vars / flags
 
 ## Configuration precedence
 
 Resolve config from highest to lowest precedence:
-1. Command flags (`--host`, `--tenant`, `--token`, `--output`)
-2. Environment variables (`KESTRACTL_HOST`, `KESTRACTL_TENANT`, `KESTRACTL_TOKEN`, `KESTRACTL_OUTPUT`)
+1. Command flags (`--host`, `--tenant`, `--token` or `--username`/`--password`, `--output`)
+2. Environment variables (`KESTRACTL_HOST`, `KESTRACTL_TENANT`, `KESTRACTL_TOKEN` or `KESTRACTL_USERNAME`/`KESTRACTL_PASSWORD`, `KESTRACTL_OUTPUT`)
 3. Config file (`~/.kestractl/config.yaml`)
 4. Built-in defaults
 
-Common setup:
+Common setup — token auth:
 
 ```bash
 kestractl config add dev http://localhost:8080 main --token DEV_TOKEN
@@ -54,6 +54,16 @@ kestractl config add prod https://prod.kestra.io production --token PROD_TOKEN
 kestractl config use dev
 kestractl config show
 ```
+
+Basic auth (username/password) — for environments that don't issue API tokens.
+Persists as `auth_method: basic` in `~/.kestractl/config.yaml`:
+
+```bash
+kestractl config add dev http://localhost:8080 main --username you@example.com --password DEV_PASSWORD --default
+```
+
+Prefer the config file or `KESTRACTL_USERNAME`/`KESTRACTL_PASSWORD` over passing
+`--password` as a flag in shared or logged shells (same guardrail as `--token`).
 
 ## Most common commands
 

--- a/skills/kestra-ops/SKILL.md
+++ b/skills/kestra-ops/SKILL.md
@@ -58,24 +58,31 @@ Resolve config from highest to lowest precedence:
 3. Config file (`~/.kestractl/config.yaml`)
 4. Built-in defaults
 
-Common setup — token auth:
+**Never paste a real token or password as a literal CLI argument** — it lands in
+shell history and the process list (`ps`). Use one of the two patterns below.
+
+Preferred — environment variables (nothing persisted, read on every command):
 
 ```bash
-kestractl config add dev http://localhost:8080 main --token DEV_TOKEN
-kestractl config add prod https://prod.kestra.io production --token PROD_TOKEN
+export KESTRACTL_HOST="https://prod.kestra.io"
+export KESTRACTL_TENANT="production"
+export KESTRACTL_TOKEN="$(cat ~/secrets/kestra_token)"   # or KESTRACTL_USERNAME + KESTRACTL_PASSWORD
+kestractl flows list my.namespace
+```
+
+Alternative — persist a context. Pass the secret via a shell variable, not a
+literal, and lock down the file:
+
+```bash
+kestractl config add dev http://localhost:8080 main --token "$KESTRACTL_TOKEN"                       # token auth
+kestractl config add oss http://localhost:8080 main --username "$KESTRACTL_USERNAME" --password "$KESTRACTL_PASSWORD"  # basic auth -> auth_method: basic
+chmod 600 ~/.kestractl/config.yaml
 kestractl config use dev
 kestractl config show
 ```
 
-Basic auth (username/password) — for environments that don't issue API tokens.
-Persists as `auth_method: basic` in `~/.kestractl/config.yaml`:
-
-```bash
-kestractl config add dev http://localhost:8080 main --username you@example.com --password DEV_PASSWORD --default
-```
-
-Prefer the config file or `KESTRACTL_USERNAME`/`KESTRACTL_PASSWORD` over passing
-`--password` as a flag in shared or logged shells (same guardrail as `--token`).
+`config add --token` / `--password` are plain flags (not env-bound), so the value
+must be on the line — keep it a `$VAR` reference, never the secret itself.
 
 ## Most common commands
 

--- a/skills/kestra-ops/references/commands.md
+++ b/skills/kestra-ops/references/commands.md
@@ -1,59 +1,446 @@
+<!--
+Source: kestra-io/kestractl @ v1.18.1 (tag) — README.md "## Usage" + src/cli/*.go help text.
+Curated, not exhaustive: command signatures, notable flags, and representative examples.
+For the long tail of flags on any command, run `kestractl <group> <command> --help`.
+Refresh this file when kestractl cuts a release that changes the CLI surface.
+EE markers ("EE only") reflect what the CLI's own help text / README states — not inference.
+-->
+
 # kestractl command reference
 
 The `kestractl` command surface used by the `kestra-ops` skill. Load this when a request
 needs a command beyond the cheat-sheet in `SKILL.md`.
 
-> This file currently covers the command groups the skill has always supported
-> (`config`, `flows`, `executions`, `namespaces`, `nsfiles`). Broader coverage
-> (`triggers`, `kv`, `plugins`, `workers`, `blueprints`, and EE-only groups) and an
-> in-depth reference sourced from the `kestractl` repo are tracked separately.
-
 ## Global flags
 
 Available on every command (see `SKILL.md` → Configuration precedence for how they resolve):
 
-- `--host` — Kestra API base URL
-- `--tenant` — tenant ID
-- `--token` — API token (prefer `KESTRACTL_TOKEN` — see `references/workflow.md` guardrails)
-- `--output` — `table` (human) or `json` (automation / parsing)
+| Flag | Purpose |
+|------|---------|
+| `--host` | Kestra API base URL |
+| `--token` / `-t` | API token — prefer the `KESTRACTL_TOKEN` env var (see `references/workflow.md` guardrails) |
+| `--username` / `--password` | Basic-auth credentials (alternative to `--token`) |
+| `--tenant` | Tenant name |
+| `--header` | Extra HTTP header, `Key:Value`, repeatable |
+| `--output` / `-o` | `table` (human, default) or `json` (scripting / parsing) |
+| `--config` | Config file path (default `~/.kestractl/config.yaml`) |
+| `--verbose` / `-v` | Verbose output — **prints credentials in HTTP requests**; never in shared logs |
+
+Command groups below are grouped OSS-first, then EE-only. EE groups return an
+authorization/edition error against an OSS instance.
+
+---
 
 ## Config
 
 ```bash
-kestractl config add dev http://localhost:8080 main --token DEV_TOKEN
-kestractl config add prod https://prod.kestra.io production --token PROD_TOKEN
-kestractl config use dev
-kestractl config show
+kestractl config add dev http://localhost:8080 main --token YOUR_TOKEN
+kestractl config add prod https://prod.kestra.io production --token PROD_TOKEN --default
+kestractl config add dev http://localhost:8080 main --token YOUR_TOKEN \
+  --header "X-Custom-Header:value"
+kestractl config show          # list all contexts
+kestractl config use prod      # switch default context
+kestractl config remove dev
 ```
 
 ## Flows
 
 ```bash
-kestractl flows list my.namespace
-kestractl flows get my.namespace my-flow
+# Read
+kestractl flows list [my.namespace]                 # alias: ls; omit ns for all namespaces
+kestractl flows list-by-namespace my.namespace --page 1 --size 50
+kestractl flows list-deprecated
+kestractl flows get my.namespace my-flow            # aliases: show, describe
+kestractl flows task my.namespace my-flow my-task-id
+kestractl flows search-by-source --query "http.request"
+kestractl flows dependencies my.namespace my-flow
+kestractl flows namespace-dependencies my.namespace
+kestractl flows expressions --namespace my.namespace --flow my-flow
+kestractl flows graph my.namespace my-flow --revision 3 --output json
+kestractl flows generate-graph-from-source --file flow.yaml
+
+# Validate
+kestractl flows validate path/to/flow.yaml
 kestractl flows validate ./flows/
+kestractl flows validate-task    --namespace my.namespace --flow my-flow --task-id my-task
+kestractl flows validate-trigger --namespace my.namespace --flow my-flow --trigger-id my-trigger
+
+# Deploy / write (aliases: create, apply)
+kestractl flows deploy path/to/flow.yaml
 kestractl flows deploy ./flows/ --namespace prod.namespace --override --fail-fast
+kestractl flows bulk-update --file flows.yaml
+kestractl flows namespace-sync my.namespace flows.yaml --delete --override
+
+# Enable / disable / delete (+ -by-query bulk variants)
+kestractl flows enable my.namespace my-flow
+kestractl flows disable my.namespace my-flow
+kestractl flows delete my.namespace my-flow
+kestractl flows delete-by-query  --namespace my.namespace --query old-
+kestractl flows disable-by-query --namespace my.namespace
+kestractl flows enable-by-query  --namespace my.namespace
+
+# Export / import
+kestractl flows export --namespace my.namespace --output-file flows.zip
+kestractl flows export-by-ids my.namespace/flow-a my.namespace/flow-b --output-file export.zip
+kestractl flows export-by-query --namespace my.namespace --output-file export.zip
+kestractl flows import flows.zip
+
+# Revisions & concurrency
+kestractl flows revisions my.namespace my-flow
+kestractl flows delete-revisions my.namespace my-flow --before-revision 5
+kestractl flows concurrency-limits my.namespace my-flow
+kestractl flows update-concurrency my.namespace my-flow --limit 10
 ```
 
 ## Executions
 
 ```bash
-kestractl executions run my.namespace my-flow --wait
-kestractl executions get 2TLGqHrXC9k8BczKJe5djX
+# Run / inspect
+kestractl executions run my.namespace my-flow [--wait]       # aliases: trigger, execute
+kestractl executions get 2TLGqHrXC9k8BczKJe5djX              # aliases: show, describe
+kestractl executions list --namespace my.namespace --flow my-flow
+kestractl executions watch 2TLGqHrXC9k8BczKJe5djX            # alias: follow; non-zero exit on failure
+kestractl executions latest --flow my.namespace:my-flow
+
+# State control
+kestractl executions kill|pause|resume|restart|force-run 2TLGqHrXC9k8BczKJe5djX
+kestractl executions replay 2TLGqHrXC9k8BczKJe5djX
+kestractl executions replay-with-inputs 2TLGqHrXC9k8BczKJe5djX --input key=value
+kestractl executions unqueue 2TLGqHrXC9k8BczKJe5djX
+kestractl executions change-status 2TLGqHrXC9k8BczKJe5djX SUCCESS
+kestractl executions update-taskrun 2TLGqHrXC9k8BczKJe5djX taskRunId SUCCESS
+
+# Labels
+kestractl executions set-labels 2TLGqHrXC9k8BczKJe5djX env=prod team=platform
+
+# Bulk by IDs
+kestractl executions set-labels-bulk env=prod --ids id1 --ids id2
+kestractl executions unqueue-bulk id1 id2 id3
+kestractl executions change-status-by-ids --status SUCCESS id1 id2
+
+# Bulk by query (--filter FIELD:OPERATION:VALUE, e.g. STATE:EQUALS:RUNNING)
+kestractl executions kill-by-query    --namespace my.namespace --flow my-flow
+kestractl executions pause-by-query   --namespace my.namespace
+kestractl executions resume-by-query  --namespace my.namespace
+kestractl executions restart-by-query --namespace my.namespace
+kestractl executions replay-by-query  --namespace my.namespace --latest-revision
+kestractl executions force-run-by-query --namespace my.namespace
+kestractl executions delete-by-query  --namespace my.namespace --delete-logs --delete-storage
+kestractl executions unqueue-by-query --namespace my.namespace
+kestractl executions set-labels-by-query env=prod --namespace my.namespace
+kestractl executions update-status-by-query --namespace my.namespace --new-status KILLED
+
+# Webhook / files / expressions
+kestractl executions trigger-webhook my.namespace my-flow my-webhook-key --method POST
+kestractl executions download-file 2TLGqHrXC9k8BczKJe5djX --path outputs/result.csv
+kestractl executions file-metadata  2TLGqHrXC9k8BczKJe5djX --path outputs/result.csv
+kestractl executions eval-expression 2TLGqHrXC9k8BczKJe5djX "{{ outputs.myTask.value }}"
+kestractl executions flow-graph 2TLGqHrXC9k8BczKJe5djX
+kestractl executions delete 2TLGqHrXC9k8BczKJe5djX
+```
+
+## Triggers
+
+```bash
+kestractl triggers list
+kestractl triggers search-for-flow my.namespace my-flow
+kestractl triggers enable|disable|unlock|restart my.namespace my-flow my-trigger
+kestractl triggers update my.namespace my-flow my-trigger --disabled
+kestractl triggers delete my.namespace my-flow my-trigger
+
+# Bulk by IDs (namespace/flowId/triggerId) and by query
+kestractl triggers delete-by-ids  my.ns/my-flow/sched
+kestractl triggers enable-by-ids|disable-by-ids|unlock-by-ids my.ns/my-flow/sched
+kestractl triggers delete-by-query|unlock-by-query|disable-by-query|enable-by-query --namespace my.namespace
+
+# Backfill (single / by-ids / by-query)
+kestractl triggers create-backfill my.namespace my-flow my-trigger \
+  --start 2024-01-01T00:00:00Z --end 2024-02-01T00:00:00Z
+kestractl triggers backfill-pause|backfill-unpause|backfill-delete my.namespace my-flow my-trigger
+kestractl triggers pause-backfill-by-query|unpause-backfill-by-query|delete-backfill-by-query --namespace my.namespace
+
+kestractl triggers export-csv --output-file triggers.csv
 ```
 
 ## Namespaces
 
 ```bash
-kestractl namespaces list
-kestractl namespaces list --query my.namespace
+kestractl namespaces list [--query my.namespace]     # alias: ls
+kestractl namespaces autocomplete --query my.
+kestractl namespaces get my.namespace
+kestractl namespaces create my.namespace
+kestractl namespaces update my.namespace --description "Production namespace"
+kestractl namespaces delete my.namespace
+
+# Variables — replaces the full variable set on the namespace
+kestractl namespaces create my.namespace --variable env=prod --variable region=eu
+kestractl namespaces update my.namespace --variables-file variables.yml
+
+kestractl namespaces inherited-secrets   my.namespace
+kestractl namespaces inherited-variables my.namespace
+kestractl namespaces plugin-defaults my.namespace
+kestractl namespaces export-plugin-defaults my.namespace --output-file defaults.yaml
+kestractl namespaces import-plugin-defaults my.namespace defaults.yaml
 ```
 
-## Namespace files
+## Key-Value Store (kv)
+
+Types: `STRING`, `NUMBER`, `BOOLEAN`, `DATETIME`, `DATE`, `DURATION`, `JSON`.
 
 ```bash
-kestractl nsfiles list my.namespace --path workflows/ --recursive
-kestractl nsfiles get my.namespace workflows/example.yaml --revision 3
+kestractl kv list [my.namespace]
+kestractl kv set my.namespace STRING api_key "my-secret"
+kestractl kv set my.namespace JSON settings '{"feature":true}'
+kestractl kv set my.namespace STRING session_token "abc" --ttl PT1H     # ISO-8601 duration
+kestractl kv update my.namespace NUMBER retries 5                        # fails if key absent
+kestractl kv get my.namespace api_key
+kestractl kv delete my.namespace api_key                                # alias: rm
+```
+
+## Namespace Files (nsfiles)
+
+```bash
+kestractl nsfiles list my.namespace [--path workflows/] [--recursive]   # alias: ls
+kestractl nsfiles get my.namespace workflows/example.yaml [--revision 3]  # alias: cat
+kestractl nsfiles upload my.namespace ./local.txt workflows/local.txt
 kestractl nsfiles upload my.namespace ./assets resources --override --fail-fast
+kestractl nsfiles upload my.namespace ./assets resources --allow-missing-namespace
+kestractl nsfiles delete my.namespace workflows/example.yaml [--force]
 kestractl nsfiles delete my.namespace workflows --recursive
+```
+
+`upload <ns> <localDir> <remotePath>` nests `localDir`'s basename under `remotePath`
+(`./assets` → `resources` yields `resources/assets/...`). Use `--no-root` to place the
+directory *contents* directly under the destination, or upload files one-by-one.
+
+## Plugins
+
+Offline plugin-JAR management for self-hosted deployments — not the running instance's plugins.
+
+```bash
+kestractl plugins download 1.3.9 [--plugins-dir ./plugins] [--concurrency 4]
+kestractl plugins download develop                       # 'develop' / 'latest' = in-dev version
+kestractl plugins download 1.3.9 --from-config /etc/kestra/application.yaml   # core plugins only
+kestractl plugins list 1.3.9 --from-config /etc/kestra/application.yaml       # preview, no download
+```
+
+## Workers
+
+```bash
+kestractl workers registration-tokens generate          # offline, no instance required
+```
+
+## Logs
+
+```bash
+kestractl logs list <execution_id>                       # alias: ls
+kestractl logs search                                    # across the tenant, free-text + filters
+kestractl logs download <execution_id> --output-file exec.log
+kestractl logs delete <execution_id>                     # alias: rm
+kestractl logs delete-flow <namespace> <flow_id>         # all logs for a flow, all executions
+```
+
+## Secrets
+
+```bash
+kestractl secrets list <namespace>                       # alias: ls
+kestractl secrets set <namespace> <key> <value>
+kestractl secrets patch <namespace> <key>               # update metadata (description)
+kestractl secrets delete <namespace> <key>               # alias: rm
+```
+
+## Server
+
+```bash
+kestractl server license                                 # license information
+kestractl server actions                                 # available server actions
+kestractl server generate                                # statistics report
+```
+
+## Blueprints
+
+`community` is public/OSS. `flow` and `custom` subcommands are **EE only**.
+
+```bash
+kestractl blueprints community search --query "kafka" [--output json]
+kestractl blueprints community get <id>
+kestractl blueprints community source <id>              # flow YAML source
+kestractl blueprints community graph <id> --output json
+
+# EE only
+kestractl blueprints flow list|get|create|update|delete ...
+kestractl blueprints flow use-template <id> --input env=prod --input region=eu
+kestractl blueprints custom get|source|create|update|delete ...
+```
+
+---
+
+# Enterprise Edition command groups
+
+All groups below require Kestra EE (as stated in the CLI's own help text). They fail
+with an authorization/edition error on OSS. Gate on edition before offering them
+(see `references/workflow.md`).
+
+## Dashboards — EE only
+
+```bash
+kestractl dashboards list [--query my-dashboard] [--output json]     # alias: ls
+kestractl dashboards get <id>                                        # aliases: show, describe
+kestractl dashboards create --file my-dashboard.yaml
+kestractl dashboards update <id> --file my-dashboard.yaml
+kestractl dashboards delete <id>                                     # alias: rm
+kestractl dashboards validate --file my-dashboard.yaml
+kestractl dashboards validate-chart --file my-chart.yaml
+kestractl dashboards preview-chart --file my-chart.yaml --output json
+kestractl dashboards chart-data <dashboard-id> <chart-id> [--file filters.yaml]
+kestractl dashboards export-chart-csv --file my-chart.yaml --output-file chart.csv
+kestractl dashboards export-chart-data-csv <dashboard-id> <chart-id> --output-file chart.csv
+```
+
+## Apps — EE only
+
+Low-code interfaces built on top of flows.
+
+```bash
+kestractl apps list [--namespace my.namespace] [--output json]       # alias: ls
+kestractl apps get <uid>                                             # aliases: show, describe
+kestractl apps deploy --file my-app.yaml
+kestractl apps update <uid> --file my-app.yaml
+kestractl apps enable|disable <uid>
+kestractl apps delete <uid>                                          # alias: rm
+kestractl apps export --output-file apps.zip
+kestractl apps import apps.zip
+kestractl apps bulk-enable|bulk-disable|bulk-delete uid-1 uid-2 [--yes]
+kestractl apps tags
+kestractl apps catalog [--query reporting] [--output json]
+kestractl apps file-meta|file-preview <view-id> --path /path/to/file
+kestractl apps logs <view-id> --min-level ERROR --output-file app.log
+```
+
+## Assets — EE only
+
+```bash
+kestractl assets list [--output json]                                # alias: ls
+kestractl assets get <id>                                            # aliases: show, describe
+kestractl assets create --name my-asset --file asset.csv
+kestractl assets delete <id>                                         # alias: rm
+kestractl assets dependencies <id> --expand-all --output json        # alias: deps
+kestractl assets delete-by-ids id1 id2 id3
+kestractl assets delete-by-query --namespace my.namespace [--purge]
+kestractl assets lineage-events list|delete-by-query ...             # alias: lineage
+kestractl assets usages list|delete-by-query ...                    # alias: usage
+```
+
+## Test Suites — EE only
+
+```bash
+kestractl test-suites list [--namespace my.namespace]                # alias: ls
+kestractl test-suites get my.namespace my-test-suite
+kestractl test-suites create --file suite.yaml
+kestractl test-suites update my.namespace my-test-suite --file suite.yaml
+kestractl test-suites validate --file suite.yaml
+kestractl test-suites run my.namespace my-test-suite
+kestractl test-suites run-by-query --namespace my.namespace
+kestractl test-suites delete-bulk|disable-bulk|enable-bulk my.namespace/suite-a
+kestractl test-suites search-results --namespace my.namespace
+kestractl test-suites last-result --ids my.namespace/suite-a
+kestractl test-suites get-result <result_id>
+kestractl test-suites delete my.namespace my-test-suite
+```
+
+## Users — EE only
+
+Instance-level resources. Use `--user-password` to set a user's password (not the
+global `--password` basic-auth flag).
+
+```bash
+kestractl users list [--query alice] [--output json]                 # alias: ls
+kestractl users get <user_id>                                        # aliases: show, describe
+kestractl users autocomplete --query ali
+kestractl users create --email alice@example.com --first-name Alice --user-password 'S3cret!'
+kestractl users create --email bob@example.com --superadmin
+kestractl users update <user_id> --first-name Alicia
+kestractl users set-password <user_id> --user-password 'N3wPass!'
+kestractl users change-my-password --old-password 'OldPass!' --new-password 'N3wPass!'
+kestractl users set-super-admin <user_id> --superadmin[=false]
+kestractl users set-restricted <user_id> --restricted=true
+kestractl users delete-auth-method <user_id> BASIC_AUTH
+kestractl users set-groups <user_id> --group <group_id>
+kestractl users impersonate <user_id>
+kestractl users revoke-refresh-token <user_id>
+kestractl users delete <user_id> [--yes]                             # alias: rm
+kestractl users tokens create|list|delete <user_id> [<token_id>] --name ci-token
+```
+
+## Groups — EE only
+
+Tenant-scoped resources.
+
+```bash
+kestractl groups list [--query admins] [--output json]               # alias: ls
+kestractl groups get <group_id>                                      # aliases: show, describe
+kestractl groups autocomplete --query adm
+kestractl groups list-by-ids <id1> <id2>
+kestractl groups create --name admins --description 'Platform admins' [--member <user_id>]
+kestractl groups update <group_id> --name platform-admins
+kestractl groups set-membership <group_id> <user_id>
+kestractl groups delete <group_id> [--yes]                           # alias: rm
+kestractl groups members list|add|remove <group_id> [<user_id>]
+```
+
+## Roles — EE only
+
+Tenant-scoped. Permissions: `--permission TYPE:LEVEL[,LEVEL]` (repeatable) or
+`--permissions-file` (YAML/JSON) — not both. `update --permission` replaces the whole block.
+
+```bash
+kestractl roles list [--query editor] [--page 1 --size 50 --sort name:asc]   # alias: ls
+kestractl roles get <role_id>                                        # aliases: show, describe
+kestractl roles autocomplete --query edi
+kestractl roles list-from-ids <id1> <id2>
+kestractl roles create --name editor --permission FLOW:READ,CREATE,UPDATE --permission EXECUTION:READ
+kestractl roles create --name viewer --permissions-file perms.yaml
+kestractl roles update <role_id> --permission FLOW:READ,CREATE,UPDATE,DELETE
+kestractl roles update <role_id> --default
+kestractl roles delete <role_id> [--yes]                             # alias: rm
+```
+
+## Service Accounts — EE only
+
+Instance-level resources (aliases: `service-account`, `sa`). `update` is a partial
+update of name/description only.
+
+```bash
+kestractl service-accounts list [--output json] [--page 1 --size 50 --sort name:asc]   # alias: ls
+kestractl service-accounts get <service_account_id>                  # aliases: show, describe
+kestractl service-accounts create --name ci-bot --description "CI pipeline"
+kestractl service-accounts create --name ops-bot --superadmin --tenant-grant main
+kestractl service-accounts update <service_account_id> --name new-bot-name
+kestractl service-accounts set-super-admin <service_account_id> --superadmin[=false]
+kestractl service-accounts delete <service_account_id> [--yes]       # alias: rm
+kestractl service-accounts tokens create|list|delete <service_account_id> [<token_id>] \
+  --name deploy-token [--max-age P30D --extended]
+```
+
+## Bindings — EE only
+
+Assign a role to a user, group, or service account within a tenant.
+
+```bash
+kestractl bindings list [--output json]                              # alias: ls
+kestractl bindings get <binding_id>                                  # aliases: show, describe
+kestractl bindings create --role <role_id> --user <user_id>
+kestractl bindings create --role <role_id> --group <group_id>
+kestractl bindings bulk-create --file bindings.json
+kestractl bindings delete <binding_id>                               # alias: rm
+```
+
+## Invitations — EE only
+
+```bash
+kestractl invitations list [--output json]
+kestractl invitations list-by-email user@example.com
+kestractl invitations get <invitation_id>
+kestractl invitations create --email user@example.com --role <role_id>
+kestractl invitations delete <invitation_id>                         # alias: rm
 ```

--- a/skills/kestra-ops/references/commands.md
+++ b/skills/kestra-ops/references/commands.md
@@ -1,0 +1,59 @@
+# kestractl command reference
+
+The `kestractl` command surface used by the `kestra-ops` skill. Load this when a request
+needs a command beyond the cheat-sheet in `SKILL.md`.
+
+> This file currently covers the command groups the skill has always supported
+> (`config`, `flows`, `executions`, `namespaces`, `nsfiles`). Broader coverage
+> (`triggers`, `kv`, `plugins`, `workers`, `blueprints`, and EE-only groups) and an
+> in-depth reference sourced from the `kestractl` repo are tracked separately.
+
+## Global flags
+
+Available on every command (see `SKILL.md` → Configuration precedence for how they resolve):
+
+- `--host` — Kestra API base URL
+- `--tenant` — tenant ID
+- `--token` — API token (prefer `KESTRACTL_TOKEN` — see `references/workflow.md` guardrails)
+- `--output` — `table` (human) or `json` (automation / parsing)
+
+## Config
+
+```bash
+kestractl config add dev http://localhost:8080 main --token DEV_TOKEN
+kestractl config add prod https://prod.kestra.io production --token PROD_TOKEN
+kestractl config use dev
+kestractl config show
+```
+
+## Flows
+
+```bash
+kestractl flows list my.namespace
+kestractl flows get my.namespace my-flow
+kestractl flows validate ./flows/
+kestractl flows deploy ./flows/ --namespace prod.namespace --override --fail-fast
+```
+
+## Executions
+
+```bash
+kestractl executions run my.namespace my-flow --wait
+kestractl executions get 2TLGqHrXC9k8BczKJe5djX
+```
+
+## Namespaces
+
+```bash
+kestractl namespaces list
+kestractl namespaces list --query my.namespace
+```
+
+## Namespace files
+
+```bash
+kestractl nsfiles list my.namespace --path workflows/ --recursive
+kestractl nsfiles get my.namespace workflows/example.yaml --revision 3
+kestractl nsfiles upload my.namespace ./assets resources --override --fail-fast
+kestractl nsfiles delete my.namespace workflows --recursive
+```

--- a/skills/kestra-ops/references/commands.md
+++ b/skills/kestra-ops/references/commands.md
@@ -29,6 +29,9 @@ Available on every command (see `SKILL.md` → Configuration precedence for how 
 Command groups below are grouped OSS-first, then EE-only. EE groups return an
 authorization/edition error against an OSS instance.
 
+`export KESTRACTL_SKILL_SOURCE=kestra-ops` once per session before running any of
+these — telemetry attribution only, no behavior change (see `references/workflow.md`).
+
 ---
 
 ## Config

--- a/skills/kestra-ops/references/commands.md
+++ b/skills/kestra-ops/references/commands.md
@@ -34,22 +34,25 @@ authorization/edition error against an OSS instance.
 ## Config
 
 ```bash
-# Token auth
-kestractl config add dev http://localhost:8080 main --token YOUR_TOKEN
-kestractl config add prod https://prod.kestra.io production --token PROD_TOKEN --default
+# Token auth — pass the secret as a $VAR, never a literal (shell history / ps)
+kestractl config add dev http://localhost:8080 main --token "$KESTRACTL_TOKEN"
+kestractl config add prod https://prod.kestra.io production --token "$KESTRACTL_TOKEN" --default
 
 # Basic auth (username/password) — persists as auth_method: basic
-kestractl config add dev http://localhost:8080 main --username you@example.com --password YOUR_PASSWORD --default
+kestractl config add oss http://localhost:8080 main --username "$KESTRACTL_USERNAME" --password "$KESTRACTL_PASSWORD" --default
 
-kestractl config add dev http://localhost:8080 main --token YOUR_TOKEN \
+kestractl config add dev http://localhost:8080 main --token "$KESTRACTL_TOKEN" \
   --header "X-Custom-Header:value"
-kestractl config show          # list all contexts
+chmod 600 ~/.kestractl/config.yaml
+kestractl config show          # list all contexts (token shown as [REDACTED])
 kestractl config use prod      # switch default context
 kestractl config remove dev
 ```
 
-Prefer the config file or `KESTRACTL_TOKEN` / `KESTRACTL_USERNAME` + `KESTRACTL_PASSWORD`
-over passing `--token` / `--password` as flags in shared or logged shells.
+Better still, skip `config add` and export `KESTRACTL_HOST` / `KESTRACTL_TENANT` /
+`KESTRACTL_TOKEN` (or `KESTRACTL_USERNAME` + `KESTRACTL_PASSWORD`) — read on every
+command, nothing written to disk. `config add --token` / `--password` are plain
+flags (not env-bound), so their value must appear on the line; keep it a `$VAR`.
 
 ## Flows
 

--- a/skills/kestra-ops/references/commands.md
+++ b/skills/kestra-ops/references/commands.md
@@ -34,14 +34,22 @@ authorization/edition error against an OSS instance.
 ## Config
 
 ```bash
+# Token auth
 kestractl config add dev http://localhost:8080 main --token YOUR_TOKEN
 kestractl config add prod https://prod.kestra.io production --token PROD_TOKEN --default
+
+# Basic auth (username/password) — persists as auth_method: basic
+kestractl config add dev http://localhost:8080 main --username you@example.com --password YOUR_PASSWORD --default
+
 kestractl config add dev http://localhost:8080 main --token YOUR_TOKEN \
   --header "X-Custom-Header:value"
 kestractl config show          # list all contexts
 kestractl config use prod      # switch default context
 kestractl config remove dev
 ```
+
+Prefer the config file or `KESTRACTL_TOKEN` / `KESTRACTL_USERNAME` + `KESTRACTL_PASSWORD`
+over passing `--token` / `--password` as flags in shared or logged shells.
 
 ## Flows
 

--- a/skills/kestra-ops/references/workflow.md
+++ b/skills/kestra-ops/references/workflow.md
@@ -9,6 +9,8 @@ signatures live in [`commands.md`](commands.md).
 1. Confirm `kestractl` is present and meets the minimum version — run
    [`../scripts/ensure-kestractl.sh`](../scripts/ensure-kestractl.sh) (dry-run;
    installs only with `--install`). Note the resolved version for the report.
+   Then `export KESTRACTL_SKILL_SOURCE=kestra-ops` for the session (telemetry
+   attribution only; no effect on behavior; skip if `KESTRACTL_TELEMETRY_DISABLED`).
 2. Resolve and confirm the target context (host, tenant, context name) and the
    **Kestra edition** (OSS / EE) — see Edition awareness below.
 4. Run read-only discovery first (`list` / `get` / `search*`).

--- a/skills/kestra-ops/references/workflow.md
+++ b/skills/kestra-ops/references/workflow.md
@@ -134,9 +134,10 @@ fine, e.g. one retry on a transient connectivity blip.
   `nsfiles delete --recursive`, `namespace-sync --delete`): confirm scope, show the
   matching read first, use `--force` / `--yes` only intentionally.
 - Never auto-run an EE command against an OSS instance to test edition.
-- Prefer env vars or the config file over credential flags on the command line —
-  `KESTRACTL_TOKEN` over `--token`, `KESTRACTL_USERNAME` / `KESTRACTL_PASSWORD` over
-  `--password` (both land in shell history and the process list).
+- Never a literal token/password as a CLI argument — it lands in shell history and
+  the process list (`ps`). Prefer env vars (`KESTRACTL_TOKEN`, or
+  `KESTRACTL_USERNAME` / `KESTRACTL_PASSWORD`) read on every command; if persisting
+  via `config add`, pass the secret as a `$VAR` and `chmod 600 ~/.kestractl/config.yaml`.
 
 ## Ops report format
 

--- a/skills/kestra-ops/references/workflow.md
+++ b/skills/kestra-ops/references/workflow.md
@@ -1,0 +1,28 @@
+# kestra-ops operational workflow
+
+How to run a `kestra-ops` request safely. Load this when the task is about *how* to
+sequence an operation, not just which command to type.
+
+## Standard workflow
+
+1. Resolve and confirm the target context.
+2. Run read-only discovery first.
+3. Validate artifacts before any deployment.
+4. Execute the requested operation with explicit flags.
+5. Verify outcomes (`--wait` for run operations where needed).
+6. Return a concise ops report with results and follow-up actions.
+
+## Guardrails
+
+- Confirm production context before write operations (`deploy`, `upload`, `delete`).
+- Prefer `flows validate` before `flows deploy`.
+- Use `--output json` for scripting and automation reliability.
+- Avoid `--verbose` in shared logs because it can expose credentials.
+- For destructive `nsfiles` actions, confirm path scope and only use `--force` intentionally.
+
+## Ops report format
+
+- Context used (host, tenant, context name)
+- Commands executed (grouped by read vs write)
+- Results (success/failure and key IDs)
+- Risks, rollback notes, and follow-up actions

--- a/skills/kestra-ops/references/workflow.md
+++ b/skills/kestra-ops/references/workflow.md
@@ -101,6 +101,27 @@ Safe.
 - **Explicit flags always:** `--namespace`, `--override`, `--fail-fast`, `--yes`
   are never assumed — pass them deliberately or not at all.
 
+## Failure handling
+
+`kestractl` exits `1` for **any** command error (Cobra `RunE` → `os.Exit(1)`) and
+writes a message to stderr. There are no per-class exit codes — **classify by the
+stderr message, not the exit code.** A non-zero exit from `flows validate` or
+`executions watch` is a *result* signal (the flow is invalid / the execution
+failed), not a CLI malfunction — treat those per their rows below.
+
+| Class | Signal | What to do |
+|-------|--------|-----------|
+| **Auth** | `401`, `unauthorized`, `invalid token`, `authentication failed` | Stop. Surface it and prompt for re-auth (new token, or `config add`/`config use`). **Never retry a write with the same credentials.** |
+| **Connectivity** | `connection refused`, `no such host`, `i/o timeout`, `context deadline exceeded`, TLS errors | Stop and report the host that failed. **Do not** silently retry against another configured context — confirm the target with the user first. |
+| **Validation** | `flows validate` (or `dashboards validate` / `test-suites validate`) exits non-zero | Expected outcome, not a recoverable error. Surface the reported detail (constraint / line) and **do not proceed to `deploy`**. |
+| **Partial / bulk** | `deploy ./dir/`, `nsfiles upload ./dir`, `*-by-query`, `*-bulk` exits non-zero | Some items may have succeeded. Re-list or parse the JSON output and report **which items succeeded and which failed**, item by item — never a single pass/fail. Do not assume `--fail-fast` was set (without it, later items still ran). |
+| **Not found / conflict** | `404`, `not found`, `already exists` | Report as-is. For `already exists` on a write, ask before re-running with `--override`. |
+
+**Never auto-retry a write** (`deploy`, `run`, `upload`, `delete`, `set`,
+`enable`/`disable`, `*-by-query`, `*-bulk`, `namespace-sync`) after a failure —
+the partial state is unknown. Read-only retries (`list`, `get`, `search*`) are
+fine, e.g. one retry on a transient connectivity blip.
+
 ## Guardrails
 
 - Confirm production context before any write (`deploy`, `run`, `upload`, `delete`,
@@ -122,4 +143,6 @@ Safe.
 - Context used (host, tenant, context name, edition, kestractl version)
 - Commands executed (grouped by read vs write)
 - Results (success / failure and key IDs; for bulk ops, counts per outcome)
+- Failures, if any: the class (auth / connectivity / validation / partial / …), the
+  stderr detail, and — for bulk ops — the per-item success/failure list
 - Risks, rollback notes, and follow-up actions

--- a/skills/kestra-ops/references/workflow.md
+++ b/skills/kestra-ops/references/workflow.md
@@ -1,28 +1,120 @@
 # kestra-ops operational workflow
 
 How to run a `kestra-ops` request safely. Load this when the task is about *how* to
-sequence an operation, not just which command to type.
+sequence and decide an operation, not just which command to type — command
+signatures live in [`commands.md`](commands.md).
 
 ## Standard workflow
 
-1. Resolve and confirm the target context.
-2. Run read-only discovery first.
-3. Validate artifacts before any deployment.
-4. Execute the requested operation with explicit flags.
-5. Verify outcomes (`--wait` for run operations where needed).
-6. Return a concise ops report with results and follow-up actions.
+1. Resolve and confirm the target context (host, tenant, context name) and the
+   **Kestra edition** (OSS / EE) — see Edition awareness below.
+2. Run read-only discovery first (`list` / `get` / `search*`).
+3. Validate artifacts before any write (`flows validate`, `dashboards validate`,
+   `test-suites validate`).
+4. Execute the requested operation with explicit flags — never rely on defaults for
+   `--namespace`, `--override`, `--fail-fast`.
+5. Verify outcomes: `--wait` / `executions watch` for runs, a follow-up `get` /
+   `list` for writes.
+6. Return a concise ops report (see Ops report format).
+
+## Edition awareness
+
+The user states the edition up front (it is a required input). Do not probe for it.
+
+- **EE-only command groups:** `dashboards`, `apps`, `assets`, `test-suites`, `users`,
+  `groups`, `roles`, `service-accounts`, `bindings`, `invitations`, and the
+  `blueprints flow` / `blueprints custom` subcommands. Everything else is OSS.
+- If the request needs an EE-only group and the edition is OSS (or unknown):
+  **stop and say so** — name the group, state that it requires EE, and offer the
+  closest OSS alternative if one exists. Do not run the command "to see if it works".
+- If the edition is unknown and the request is OSS-only, proceed and note the
+  assumption in the report.
+- An EE command run against OSS returns an authorization/edition error — handle it
+  per the failure-handling section, do not retry.
+
+## Per-group decision notes
+
+**flows** — Discovery: `list`, `get`, `dependencies`, `namespace-dependencies`.
+Always `flows validate` before `flows deploy`. `deploy` of a directory is a bulk
+write: set `--namespace` explicitly, use `--override` only when replacing is
+intended, `--fail-fast` to stop on first error. Before any destructive change to a
+live flow (`delete`, `namespace-sync --delete`, `bulk-update`), check `flows
+revisions` so a rollback target is known; `delete-revisions` is irreversible.
+`namespace-sync ... --delete` removes flows absent from the file — confirm the file
+is complete first.
+
+**executions** — `run` starts a write (the flow does whatever it does). Use `--wait`
+(or `executions watch`, which exits non-zero on failure) when the caller needs the
+result inline and the flow is short/bounded; use fire-and-poll (`run`, then
+`executions get <id>`) for long-running flows or when you only need the execution
+ID. State-control verbs (`kill`, `pause`, `resume`, `restart`, `replay`,
+`force-run`, `change-status`) act on live executions — confirm the target ID and
+current state first. `delete-by-query --delete-logs --delete-storage` is
+destructive and wide — always dry-run the matching `executions list` with the same
+filters first and report the count.
+
+**triggers** — Discovery: `list`, `search-for-flow`. `enable` / `disable` /
+`update --disabled` change scheduling behavior on a live flow — confirm before prod.
+`unlock` clears a stuck lock (safe, but note why it was locked). Backfills
+(`create-backfill`, `*-backfill-by-query`) can enqueue a large number of
+executions — confirm the `--start` / `--end` window and expected volume before
+running.
+
+**kv** — `list` / `get` are safe. `set` overwrites silently; `update` fails if the
+key is absent (use it when you mean "must already exist"). `delete` is immediate
+with no revision history. Namespace KV values may be read by running flows — treat
+prod writes as production changes.
+
+**nsfiles** — `list` / `get` are safe. `upload` of a directory nests the source
+dir name under the destination unless `--no-root` is passed (see `commands.md`).
+`delete --recursive` removes a whole subtree; confirm the path scope and prefer a
+prior `list --recursive` to show exactly what will go. `--force` only to ignore
+missing targets, never as a reflex.
+
+**blueprints** — `community search` / `community get` / `community source` are
+read-only and OSS — safe for discovery and for pulling a starting flow YAML.
+`blueprints flow` / `blueprints custom` are EE.
+
+**plugins** — Offline plugin-JAR download for self-hosted deployments; does not
+touch the running instance. Read-mostly and safe.
+
+**workers** — `registration-tokens generate` runs offline, no instance required.
+Safe.
+
+## Cross-cutting decision rules
+
+- **`--output json` for anything you parse or report on.** Reserve `table` for
+  output shown directly to a human with no further processing. Never screen-scrape
+  `table`.
+- **Prefer `*-by-query` / `*-bulk` over a scripted loop** of single-item commands
+  (`delete-by-query`, `disable-by-query`, `set-labels-by-query`, `*-bulk`, ...):
+  one atomic server-side operation, one result to report. Before running a
+  `*-by-query` **write**, run the matching read (`list` with the same `--namespace`
+  / `--filter`) and report how many items match.
+- **`--wait` vs. poll:** `--wait` / `watch` for short bounded runs where the result
+  is needed now; `run` + later `executions get` for long or fire-and-forget runs.
+- **Revision-awareness:** inspect `flows revisions` before deleting or force-syncing
+  a live flow; `delete-revisions` is irreversible.
+- **Explicit flags always:** `--namespace`, `--override`, `--fail-fast`, `--yes`
+  are never assumed — pass them deliberately or not at all.
 
 ## Guardrails
 
-- Confirm production context before write operations (`deploy`, `upload`, `delete`).
-- Prefer `flows validate` before `flows deploy`.
-- Use `--output json` for scripting and automation reliability.
-- Avoid `--verbose` in shared logs because it can expose credentials.
-- For destructive `nsfiles` actions, confirm path scope and only use `--force` intentionally.
+- Confirm production context before any write (`deploy`, `run`, `upload`, `delete`,
+  `set`, `enable` / `disable`, `*-by-query`, `*-bulk`, `namespace-sync`).
+- Validate before deploy (`flows validate`, `dashboards validate`,
+  `test-suites validate`).
+- `--output json` for anything parsed or reported; `table` only for direct display.
+- Never `--verbose` in shared logs — it prints credentials in HTTP requests.
+- Destructive actions (`delete`, `delete-revisions`, `delete-by-query`,
+  `nsfiles delete --recursive`, `namespace-sync --delete`): confirm scope, show the
+  matching read first, use `--force` / `--yes` only intentionally.
+- Never auto-run an EE command against an OSS instance to test edition.
+- Prefer `KESTRACTL_TOKEN` (env) over `--token` on the command line.
 
 ## Ops report format
 
-- Context used (host, tenant, context name)
+- Context used (host, tenant, context name, edition)
 - Commands executed (grouped by read vs write)
-- Results (success/failure and key IDs)
+- Results (success / failure and key IDs; for bulk ops, counts per outcome)
 - Risks, rollback notes, and follow-up actions

--- a/skills/kestra-ops/references/workflow.md
+++ b/skills/kestra-ops/references/workflow.md
@@ -6,16 +6,19 @@ signatures live in [`commands.md`](commands.md).
 
 ## Standard workflow
 
-1. Resolve and confirm the target context (host, tenant, context name) and the
+1. Confirm `kestractl` is present and meets the minimum version — run
+   [`../scripts/ensure-kestractl.sh`](../scripts/ensure-kestractl.sh) (dry-run;
+   installs only with `--install`). Note the resolved version for the report.
+2. Resolve and confirm the target context (host, tenant, context name) and the
    **Kestra edition** (OSS / EE) — see Edition awareness below.
-2. Run read-only discovery first (`list` / `get` / `search*`).
-3. Validate artifacts before any write (`flows validate`, `dashboards validate`,
+4. Run read-only discovery first (`list` / `get` / `search*`).
+5. Validate artifacts before any write (`flows validate`, `dashboards validate`,
    `test-suites validate`).
-4. Execute the requested operation with explicit flags — never rely on defaults for
+6. Execute the requested operation with explicit flags — never rely on defaults for
    `--namespace`, `--override`, `--fail-fast`.
-5. Verify outcomes: `--wait` / `executions watch` for runs, a follow-up `get` /
+7. Verify outcomes: `--wait` / `executions watch` for runs, a follow-up `get` /
    `list` for writes.
-6. Return a concise ops report (see Ops report format).
+8. Return a concise ops report (see Ops report format).
 
 ## Edition awareness
 
@@ -116,7 +119,7 @@ Safe.
 
 ## Ops report format
 
-- Context used (host, tenant, context name, edition)
+- Context used (host, tenant, context name, edition, kestractl version)
 - Commands executed (grouped by read vs write)
 - Results (success / failure and key IDs; for bulk ops, counts per outcome)
 - Risks, rollback notes, and follow-up actions

--- a/skills/kestra-ops/references/workflow.md
+++ b/skills/kestra-ops/references/workflow.md
@@ -110,7 +110,9 @@ Safe.
   `nsfiles delete --recursive`, `namespace-sync --delete`): confirm scope, show the
   matching read first, use `--force` / `--yes` only intentionally.
 - Never auto-run an EE command against an OSS instance to test edition.
-- Prefer `KESTRACTL_TOKEN` (env) over `--token` on the command line.
+- Prefer env vars or the config file over credential flags on the command line —
+  `KESTRACTL_TOKEN` over `--token`, `KESTRACTL_USERNAME` / `KESTRACTL_PASSWORD` over
+  `--password` (both land in shell history and the process list).
 
 ## Ops report format
 

--- a/skills/kestra-ops/scripts/ensure-kestractl.sh
+++ b/skills/kestra-ops/scripts/ensure-kestractl.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# ensure-kestractl.sh — check for kestractl and, on request, install/upgrade it
+# using the official published installer.
+#
+# Dry-run by default: prints status and, if action is needed, the exact PLAN it
+# WOULD run. Nothing is installed until you pass --install.
+#
+# Usage:
+#   ensure-kestractl.sh                       # report status + plan (no changes)
+#   ensure-kestractl.sh --install --install-dir ~/.local/bin
+#   ensure-kestractl.sh --install --install-dir "$(dirname "$0")/bin"
+#
+# Env (all optional):
+#   KESTRACTL_MIN_VERSION   minimum acceptable version   (default: 1.16.0)
+#   KESTRACTL_VERSION       version to install            (default: installer's "latest")
+#   KESTRACTL_INSTALL_DIR   install target               (same as --install-dir)
+#
+# Install-dir choice (required for --install): pick ONE of
+#   1. ~/.local/bin                  — user home scope
+#   2. <this scripts dir>/bin        — self-contained to the skill
+# Never a system path unless you pass one explicitly. No sudo.
+#
+# The published installer (OS/arch detection, GitHub-release download, sha256
+# checksum verification) is:
+#   https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh
+set -euo pipefail
+
+MIN_VERSION="${KESTRACTL_MIN_VERSION:-1.16.0}"
+WANT_VERSION="${KESTRACTL_VERSION:-}"
+INSTALL_DIR="${KESTRACTL_INSTALL_DIR:-}"
+INSTALLER_URL="https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh"
+APPLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --install)      APPLY=1 ;;
+    --install-dir)  INSTALL_DIR="${2:-}"; shift ;;
+    --install-dir=*) INSTALL_DIR="${1#*=}" ;;
+    -h|--help)      sed -n '2,32p' "$0"; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+say() { printf '%s\n' "$*"; }
+
+# Return 0 if $1 >= $2 (dotted numeric versions).
+version_ge() {
+  [ "$1" = "$2" ] && return 0
+  local lo
+  lo="$(printf '%s\n%s\n' "$1" "$2" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)"
+  [ "$lo" = "$2" ]
+}
+
+current_version() {
+  command -v kestractl >/dev/null 2>&1 || return 1
+  # First line looks like: "kestractl v1.15.0"
+  kestractl version 2>/dev/null | head -n1 | sed -E 's/^[^0-9]*//; s/[^0-9.].*$//'
+}
+
+resolved_report() {
+  local v
+  v="$(current_version || true)"
+  if [ -n "$v" ]; then
+    say "Resolved: kestractl $v ($(command -v kestractl))"
+  else
+    say "Resolved: kestractl NOT on PATH"
+  fi
+}
+
+path_warning() {
+  case ":${PATH}:" in
+    *":$1:"*) : ;;
+    *) say "NOTE: $1 is not on your PATH — add it:  export PATH=\"$1:\$PATH\"" ;;
+  esac
+}
+
+CUR="$(current_version || true)"
+
+if [ -n "$CUR" ] && version_ge "$CUR" "$MIN_VERSION"; then
+  say "OK: kestractl $CUR is installed and >= minimum $MIN_VERSION."
+  resolved_report
+  exit 0
+fi
+
+if [ -z "$CUR" ]; then
+  say "kestractl is not on PATH."
+else
+  say "kestractl $CUR is older than the minimum ($MIN_VERSION) this skill expects."
+fi
+
+# --- action needed ---------------------------------------------------------
+plan_dir_hint() {
+  say "  Choose an install dir (pass --install-dir):"
+  say "    1. \$HOME/.local/bin            (user home scope)"
+  say "    2. $(cd "$(dirname "$0")" && pwd)/bin   (self-contained to this skill)"
+}
+
+installer_env=""
+[ -n "$WANT_VERSION" ] && installer_env="VERSION=$WANT_VERSION "
+
+if [ "$APPLY" -ne 1 ]; then
+  say ""
+  say "PLAN (dry-run — nothing changed). To apply, re-run with --install --install-dir <dir>:"
+  say "  ${installer_env}INSTALL_DIR=<dir> bash -c 'curl -fsSL $INSTALLER_URL | bash'"
+  plan_dir_hint
+  say ""
+  say "After install, set up a connection context (you will be asked which):"
+  say "  # OSS (basic auth):"
+  say "  kestractl config add default http://localhost:8080 main --username YOUR_USERNAME --password YOUR_PASSWORD --default"
+  say "  # Enterprise (API token):"
+  say "  kestractl config add default https://kestra.example.com production --token YOUR_TOKEN --default"
+  say "  # config file: ~/.kestractl/config.yaml   env: KESTRACTL_HOST/TENANT/TOKEN/USERNAME/PASSWORD"
+  exit 0
+fi
+
+# --- apply ---------------------------------------------------------------
+if [ -z "$INSTALL_DIR" ]; then
+  say "ERROR: --install requires --install-dir (or KESTRACTL_INSTALL_DIR)."
+  plan_dir_hint
+  exit 2
+fi
+case "$INSTALL_DIR" in
+  "~"/*) INSTALL_DIR="$HOME/${INSTALL_DIR#\~/}" ;;
+esac
+mkdir -p "$INSTALL_DIR"
+
+say "Installing kestractl into $INSTALL_DIR via the official installer ..."
+say "  ${installer_env}INSTALL_DIR=$INSTALL_DIR  curl -fsSL $INSTALLER_URL | bash"
+if [ -n "$WANT_VERSION" ]; then
+  VERSION="$WANT_VERSION" INSTALL_DIR="$INSTALL_DIR" bash -c "curl -fsSL '$INSTALLER_URL' | bash"
+else
+  INSTALL_DIR="$INSTALL_DIR" bash -c "curl -fsSL '$INSTALLER_URL' | bash"
+fi
+
+export PATH="$INSTALL_DIR:$PATH"
+hash -r 2>/dev/null || true
+
+NEW="$(current_version || true)"
+if [ -z "$NEW" ]; then
+  say "ERROR: kestractl still not runnable after install."
+  exit 1
+fi
+if ! version_ge "$NEW" "$MIN_VERSION"; then
+  say "WARNING: installed kestractl $NEW is still below the minimum $MIN_VERSION."
+fi
+resolved_report
+path_warning "$INSTALL_DIR"
+say ""
+say "Next: set up a connection context (ask the user which edition/auth):"
+say "  kestractl config add default http://localhost:8080 main --username YOUR_USERNAME --password YOUR_PASSWORD --default   # OSS"
+say "  kestractl config add default https://kestra.example.com production --token YOUR_TOKEN --default                       # Enterprise"

--- a/skills/kestra-ops/scripts/ensure-kestractl.sh
+++ b/skills/kestra-ops/scripts/ensure-kestractl.sh
@@ -32,6 +32,9 @@ INSTALL_DIR="${KESTRACTL_INSTALL_DIR:-}"
 INSTALLER_URL="https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh"
 APPLY=0
 
+# Attribute the kestractl version probes below to this skill (telemetry only).
+export KESTRACTL_SKILL_SOURCE="${KESTRACTL_SKILL_SOURCE:-kestra-ops}"
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --install)      APPLY=1 ;;

--- a/skills/migrate-airflow-kestra/SKILL.md
+++ b/skills/migrate-airflow-kestra/SKILL.md
@@ -345,9 +345,15 @@ triggers:
 
 ## Deploying with kestra-ops
 
-After generating the files, if the user wants to deploy, use the `kestra-ops` skill. Key note on namespace file uploads: **always upload files individually** to avoid path nesting issues:
+After generating the files, if the user wants to deploy, use the `kestra-ops` skill
+(it attributes its own `kestractl` telemetry). For the inline upload below, set the
+attribution first (telemetry only; skip if `KESTRACTL_TELEMETRY_DISABLED`). Key note
+on namespace file uploads: **always upload files individually** to avoid path
+nesting issues:
 
 ```bash
+export KESTRACTL_SKILL_SOURCE=migrate-airflow-kestra
+
 for f in <output-dir>/scripts/*.py; do
   name=$(basename "$f")
   kestractl nsfiles upload <namespace> "$f" "scripts/$name" --override


### PR DESCRIPTION
Implements [epic #8](https://github.com/kestra-io/agent-skills/issues/8) — one commit per sub-issue on a single branch. **Do not merge** yet.

## Progress — 15 of 17 issues done, 2 deferred

### Phase A — `kestra-ops` maturation ✅
- [x] Closes #19 restructure into `SKILL.md` + `references/` — `9166ded`
- [x] Closes #22 in-depth `kestractl` command reference (pinned v1.18.1) — `2f76eb6`
- [x] Closes #21 broaden coverage + sharpen workflow (edition awareness, per-group rules) — `006ced4`
- [x] Closes #23 document `kestractl` basic auth — `189320f`
- [x] Closes #20 `kestractl` install/upgrade bootstrap script — `9d48479`
- [x] Closes #24 failure-handling guidance — `8a16dec`

### Phase B — `kestra-flow` ✅
- [x] Closes #5 replace 23 MB `curl` with incremental MCP loading — `c0adb50`
- [x] Closes #9 blueprint-first scaffolding — `1f0b805`
- [x] Closes #10 resolve plugins / runners / storages / secret managers via `list_*` — `0f8dd66`
- [x] Closes #7 Snyk findings wrap-up (kestra-flow + kestra-ops) — `fb4d244`

### Phase C — `kestra-flow-hardening` ✅
- [x] Closes #11 doc-grounded troubleshoot mode + MCP migration + `references/troubleshooting.md` — `e9708fa`

### Phase D — new skills
- [ ] #12 `kestra-upgrade` — **deferred** (not started, at author's request)
- [ ] #16 `migrate-camunda-kestra` — **deferred** (not started, at author's request)
- [x] Closes #13 `kestra-cicd` (GitHub Actions + GitLab CI templates) — `7151d02`

### Phase E — packaging + telemetry ✅
- [x] Closes #14 bundle as `kestra-agent-skills` plugin + `kestra-io` marketplace + README — `870bcf3`
- [x] Closes #15 `KESTRACTL_SKILL_SOURCE` attribution — `0b30e10`
- [x] Closes #17 per-skill usage hook (`hooks/skill-usage.sh` → PostHog) — `d6f3cd4`

## Cross-repo follow-up (not in this repo)

**`kestra-io/kestractl`** — `src/cli/telemetry.go`: add `telemetrySkillSourceEnv = "KESTRACTL_SKILL_SOURCE"` and, in `CaptureCommand`, `if v := os.Getenv(telemetrySkillSourceEnv); v != "" { properties.Set("skill_source", v) }` (next to `ci_provider`). Until this ships, `KESTRACTL_SKILL_SOURCE` set by the skills is simply ignored.

## Notes
- #5 and #7 were "Related" (not sub-issues) — folded in; they share code paths with #9/#10/#23.
- #12 and #16 are deferred, not dropped — pick them up in a follow-up PR or reopen against this branch.
- `migrate-airflow-kestra` still uses the old schema `curl` — intentionally left; its MCP migration is out of this epic's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
